### PR TITLE
Throwing error when insecure rng is used

### DIFF
--- a/lib/rng-browser.js
+++ b/lib/rng-browser.js
@@ -17,18 +17,7 @@ if (getRandomValues) {
     return rnds8;
   };
 } else {
-  // Math.random()-based (RNG)
-  //
-  // If all else fails, use Math.random().  It's fast, but is of unspecified
-  // quality.
-  var rnds = new Array(16);
-
-  module.exports = function mathRNG() {
-    for (var i = 0, r; i < 16; i++) {
-      if ((i & 0x03) === 0) r = Math.random() * 0x100000000;
-      rnds[i] = r >>> ((i & 0x03) << 3) & 0xff;
-    }
-
-    return rnds;
+  module.exports = function noSecureRNG() {
+    throw Error('uuid: No secure RNG available. See https://github.com/kelektiv/node-uuid/wiki#no-good-rng-error for more info.');
   };
 }

--- a/test/test.js
+++ b/test/test.js
@@ -60,16 +60,9 @@ test('nodeRNG', function() {
   }
 });
 
-test('mathRNG', function() {
+test('noSecureRNG', function() {
   var rng = require('../lib/rng-browser');
-  assert.equal(rng.name, 'mathRNG');
-
-  var bytes = rng();
-  assert.equal(bytes.length, 16);
-
-  for (var i = 0; i < bytes.length; i++) {
-    assert.equal(typeof(bytes[i]), 'number');
-  }
+  assert.throws(rng, Error)
 });
 
 test('cryptoRNG', function() {

--- a/v1.js
+++ b/v1.js
@@ -26,7 +26,7 @@ function v1(options, buf, offset) {
   // specified.  We do this lazily to minimize issues related to insufficient
   // system entropy.  See #189
   if (node == null || clockseq == null) {
-    var seedBytes = rng();
+    var seedBytes = (options.rng || rng)();
     if (node == null) {
       // Per 4.5, create and 48-bit node id, (47 random bits + multicast bit = 1)
       node = _nodeId = [


### PR DESCRIPTION
- New option for v1 and v4: allowInsecureRng
  - Require to be `true` if `rng.insecure == true`

Closes #173

----

Here's my attempt at closing #173, please let me know if a different approach is preferred.