### PR TITLE
feat: remove support for pre Node.js v4 Buffer API

### DIFF
--- a/src/md5.js
+++ b/src/md5.js
@@ -1,20 +1,10 @@
 import crypto from 'crypto';
 
 function md5(bytes) {
-  if (typeof Buffer.from === 'function') {
-    // Modern Buffer API
-    if (Array.isArray(bytes)) {
-      bytes = Buffer.from(bytes);
-    } else if (typeof bytes === 'string') {
-      bytes = Buffer.from(bytes, 'utf8');
-    }
-  } else {
-    // Pre-v4 Buffer API
-    if (Array.isArray(bytes)) {
-      bytes = new Buffer(bytes);
-    } else if (typeof bytes === 'string') {
-      bytes = new Buffer(bytes, 'utf8');
-    }
+  if (Array.isArray(bytes)) {
+    bytes = Buffer.from(bytes);
+  } else if (typeof bytes === 'string') {
+    bytes = Buffer.from(bytes, 'utf8');
   }
 
   return crypto

--- a/src/sha1.js
+++ b/src/sha1.js
@@ -1,20 +1,10 @@
 import crypto from 'crypto';
 
 function sha1(bytes) {
-  if (typeof Buffer.from === 'function') {
-    // Modern Buffer API
-    if (Array.isArray(bytes)) {
-      bytes = Buffer.from(bytes);
-    } else if (typeof bytes === 'string') {
-      bytes = Buffer.from(bytes, 'utf8');
-    }
-  } else {
-    // Pre-v4 Buffer API
-    if (Array.isArray(bytes)) {
-      bytes = new Buffer(bytes);
-    } else if (typeof bytes === 'string') {
-      bytes = new Buffer(bytes, 'utf8');
-    }
+  if (Array.isArray(bytes)) {
+    bytes = Buffer.from(bytes);
+  } else if (typeof bytes === 'string') {
+    bytes = Buffer.from(bytes, 'utf8');
   }
 
   return crypto


### PR DESCRIPTION
BREAKING CHANGE: Remove support for generating v3 and v5 UUIDs in
Node.js<4.x