### PR TITLE
docs: add link to README of stable version

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ Features:
 - Uses cryptographically-strong random number APIs
 - Zero-dependency, small footprint
 
+⚠️⚠️⚠️ This is the README of the upcoming major version of this library. You can still [access the README
+of the current stable version](https://github.com/uuidjs/uuid/blob/v3.4.0/README.md). ⚠️⚠️⚠️
+
 ## Quickstart - Node.js/CommonJS
 
 ```shell

--- a/README_js.md
+++ b/README_js.md
@@ -27,6 +27,9 @@ Features:
 - Uses cryptographically-strong random number APIs
 - Zero-dependency, small footprint
 
+⚠️⚠️⚠️ This is the README of the upcoming major version of this library. You can still [access the README
+of the current stable version](https://github.com/uuidjs/uuid/blob/v3.4.0/README.md). ⚠️⚠️⚠️
+
 ## Quickstart - Node.js/CommonJS
 
 ```shell


### PR DESCRIPTION
@broofa I would like to merge the next branch into master now and revert to trunk-based development. Having the two diverging branches already starts to cause some headache and I would like to avoid that.

I would therefore add a notice to the Readme that points to the current "stable" readme until we release the next major version of this library and then go ahead and merge the `next` branch into `master`.

I would then release the first canary prerelease of the new major version for folks to try out.

I was considering to release it as `v6.0.0` instead of `v4.0.0` in order to avoid any potential confusion around `v3`/`v4`/`v5` uuids.

WDYT?