### PR TITLE
test: remove flaky Edge 79.0 beta test

### DIFF
--- a/.github/workflows/browser.yml
+++ b/.github/workflows/browser.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
       with:
-        fetch-depth: 1
+        fetch-depth: 10
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
       with:
-        fetch-depth: 1
+        fetch-depth: 10
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:

--- a/test/browser/edge.test.js
+++ b/test/browser/edge.test.js
@@ -4,12 +4,6 @@ const browserTest = require('./browser-test');
 browserTest('edge', 9001, [
   {
     browserName: 'Edge',
-    browser_version: '79.0 beta',
-    os: 'Windows',
-    os_version: '10',
-  },
-  {
-    browserName: 'Edge',
     browser_version: '18.0',
     os: 'Windows',
     os_version: '10',


### PR DESCRIPTION
Among all browsers this one seems to be the one who causes almost all
BrowserStack timeouts. Let's remove it and add it again as soon as a
non-beta Chromium Edge version becomes available on BrowserStack.