### PR TITLE
docs: prefer esmodule import syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ Version 4 (random):
 ```javascript
 import { v4 as uuidv4 } from 'uuid';
 uuidv4(); // ⇨ '9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d'
-
 ```
 
 Or generate UUIDs with other algorithms of your choice ...
@@ -69,7 +68,6 @@ Version 1 (timestamp):
 ```javascript
 import { v1 as uuidv1 } from 'uuid';
 uuidv1(); // ⇨ '2c5ea4c0-4067-11e9-8b2d-1b9d6bcdbbfd'
-
 ```
 
 Version 3 (namespace):
@@ -89,7 +87,6 @@ uuidv3('http://example.com/hello', uuidv3.URL); // ⇨ 'c6235813-3ba4-3801-ae84-
 // E.g. the one here was generated using this modules `uuid` CLI.
 const MY_NAMESPACE = '1b671a64-40d5-491e-99b0-da01ff1f3341';
 uuidv3('Hello, World!', MY_NAMESPACE); // ⇨ 'e8b5a51d-11c8-3310-a6ab-367563f20686'
-
 ```
 
 Version 5 (namespace):
@@ -109,7 +106,6 @@ uuidv5('http://example.com/hello', uuidv5.URL); // ⇨ '3bbcee75-cecc-5b56-8031-
 // E.g. the one here was generated using this modules `uuid` CLI.
 const MY_NAMESPACE = '1b671a64-40d5-491e-99b0-da01ff1f3341';
 uuidv5('Hello, World!', MY_NAMESPACE); // ⇨ '630eb68f-e0fa-5ecc-887a-7c7a62614681'
-
 ```
 
 ## Supported Platforms
@@ -191,7 +187,6 @@ const v4options = {
   ],
 };
 uuidv4(v4options); // ⇨ '109156be-c4fb-41ea-b1b4-efe1671c5836'
-
 ```
 
 Example: Generate two IDs in a single buffer
@@ -212,7 +207,6 @@ uuidv4(null, buffer, 16); // ⇨
   //    27, 157, 107, 205, 187, 253,  75,  45,
   //   155,  93, 171, 141, 251, 189,  75, 237
   // ]
-
 ```
 
 ### Version 1 (Timestamp + Node)
@@ -256,7 +250,6 @@ const v1options = {
   nsecs: 5678,
 };
 uuidv1(v1options); // ⇨ '710b962e-041c-11e1-9234-0123456789ab'
-
 ```
 
 Example: In-place generation of two binary IDs
@@ -278,7 +271,6 @@ uuidv1(null, arr, 16); // ⇨
   //    44, 94, 164, 193,  64, 103,  17, 233,
   //   146, 52,  27, 157, 107, 205, 187, 253
   // ]
-
 ```
 
 ### Version 3 (Namespace)
@@ -305,7 +297,6 @@ Example:
 
 ```javascript
 uuidv3('hello world', MY_NAMESPACE); // ⇨ '042ffd34-d989-321c-ad06-f60826172424'
-
 ```
 
 ### Version 5 (Namespace)
@@ -332,7 +323,6 @@ Example:
 
 ```javascript
 uuidv5('hello world', MY_NAMESPACE); // ⇨ '9f282611-e0fd-5650-8953-89c8e342da0b'
-
 ```
 
 ## Command Line

--- a/README.md
+++ b/README.md
@@ -39,12 +39,11 @@ import { v4 as uuidv4 } from 'uuid';
 uuidv4();
 ```
 
-For use as CommonJS module with Node.js (where bundlesize is no concern) just require the main
-package:
+For use as CommonJS module with Node.js you can use:
 
 ```javascript
-const uuid = require('uuid');
-uuid.v4();
+const { v4: uuidv4 } = require('uuid');
+uuidv4();
 ```
 
 ## Quickstart - Node.js/CommonJS
@@ -58,8 +57,8 @@ Then generate a random UUID (v4 algorithm), which is almost always what you want
 Version 4 (random):
 
 ```javascript
-const uuid = require('uuid');
-uuid.v4(); // ⇨ '9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d'
+import { v4 as uuidv4 } from 'uuid';
+uuidv4(); // ⇨ '9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d'
 
 ```
 
@@ -68,48 +67,48 @@ Or generate UUIDs with other algorithms of your choice ...
 Version 1 (timestamp):
 
 ```javascript
-const uuid = require('uuid');
-uuid.v1(); // ⇨ '2c5ea4c0-4067-11e9-8b2d-1b9d6bcdbbfd'
+import { v1 as uuidv1 } from 'uuid';
+uuidv1(); // ⇨ '2c5ea4c0-4067-11e9-8b2d-1b9d6bcdbbfd'
 
 ```
 
 Version 3 (namespace):
 
 ```javascript
-const uuid = require('uuid');
+import { v3 as uuidv3 } from 'uuid';
 
 // ... using predefined DNS namespace (for domain names)
-uuid.v3('hello.example.com', uuid.v3.DNS); // ⇨ '9125a8dc-52ee-365b-a5aa-81b0b3681cf6'
+uuidv3('hello.example.com', uuidv3.DNS); // ⇨ '9125a8dc-52ee-365b-a5aa-81b0b3681cf6'
 
 // ... using predefined URL namespace (for, well, URLs)
-uuid.v3('http://example.com/hello', uuid.v3.URL); // ⇨ 'c6235813-3ba4-3801-ae84-e0a6ebb7d138'
+uuidv3('http://example.com/hello', uuidv3.URL); // ⇨ 'c6235813-3ba4-3801-ae84-e0a6ebb7d138'
 
 // ... using a custom namespace
 //
 // Note: Custom namespaces should be a UUID string specific to your application!
 // E.g. the one here was generated using this modules `uuid` CLI.
 const MY_NAMESPACE = '1b671a64-40d5-491e-99b0-da01ff1f3341';
-uuid.v3('Hello, World!', MY_NAMESPACE); // ⇨ 'e8b5a51d-11c8-3310-a6ab-367563f20686'
+uuidv3('Hello, World!', MY_NAMESPACE); // ⇨ 'e8b5a51d-11c8-3310-a6ab-367563f20686'
 
 ```
 
 Version 5 (namespace):
 
 ```javascript
-const uuid = require('uuid');
+import { v5 as uuidv5 } from 'uuid';
 
 // ... using predefined DNS namespace (for domain names)
-uuid.v5('hello.example.com', uuid.v5.DNS); // ⇨ 'fdda765f-fc57-5604-a269-52a7df8164ec'
+uuidv5('hello.example.com', uuidv5.DNS); // ⇨ 'fdda765f-fc57-5604-a269-52a7df8164ec'
 
 // ... using predefined URL namespace (for, well, URLs)
-uuid.v5('http://example.com/hello', uuid.v5.URL); // ⇨ '3bbcee75-cecc-5b56-8031-b6641c1ed1f1'
+uuidv5('http://example.com/hello', uuidv5.URL); // ⇨ '3bbcee75-cecc-5b56-8031-b6641c1ed1f1'
 
 // ... using a custom namespace
 //
 // Note: Custom namespaces should be a UUID string specific to your application!
 // E.g. the one here was generated using this modules `uuid` CLI.
 const MY_NAMESPACE = '1b671a64-40d5-491e-99b0-da01ff1f3341';
-uuid.v5('Hello, World!', MY_NAMESPACE); // ⇨ '630eb68f-e0fa-5ecc-887a-7c7a62614681'
+uuidv5('Hello, World!', MY_NAMESPACE); // ⇨ '630eb68f-e0fa-5ecc-887a-7c7a62614681'
 
 ```
 
@@ -150,12 +149,12 @@ npm run build
 ### Version 4 (Random)
 
 ```javascript
-const uuid = require('uuid');
+import { v4 as uuidv4 } from 'uuid';
 
 // Incantations
-uuid.v4();
-uuid.v4(options);
-uuid.v4(options, buffer, offset);
+uuidv4();
+uuidv4(options);
+uuidv4(options, buffer, offset);
 ```
 
 Generate and return a RFC4122 v4 UUID.
@@ -191,7 +190,7 @@ const v4options = {
     0x36,
   ],
 };
-uuid.v4(v4options); // ⇨ '109156be-c4fb-41ea-b1b4-efe1671c5836'
+uuidv4(v4options); // ⇨ '109156be-c4fb-41ea-b1b4-efe1671c5836'
 
 ```
 
@@ -199,14 +198,14 @@ Example: Generate two IDs in a single buffer
 
 ```javascript
 const buffer = new Array();
-uuid.v4(null, buffer, 0); // ⇨ 
+uuidv4(null, buffer, 0); // ⇨ 
   // [
   //   155, 29, 235,  77,  59,
   //   125, 75, 173, 155, 221,
   //    43, 13, 123,  61, 203,
   //   109
   // ]
-uuid.v4(null, buffer, 16); // ⇨ 
+uuidv4(null, buffer, 16); // ⇨ 
   // [
   //   155,  29, 235,  77,  59, 125,  75, 173,
   //   155, 221,  43,  13, 123,  61, 203, 109,
@@ -223,12 +222,12 @@ before using them. In many cases, Version 4 random UUIDs are the better choice. 
 FAQ](https://github.com/tc39/proposal-uuid#faq) covers more details.** ⚠️⚠️⚠️
 
 ```javascript
-const uuid = require('uuid');
+import { v1 as uuidv1 } from 'uuid';
 
 // Incantations
-uuid.v1();
-uuid.v1(options);
-uuid.v1(options, buffer, offset);
+uuidv1();
+uuidv1(options);
+uuidv1(options, buffer, offset);
 ```
 
 Generate and return a RFC4122 v1 (timestamp-based) UUID.
@@ -256,7 +255,7 @@ const v1options = {
   msecs: new Date('2011-11-01').getTime(),
   nsecs: 5678,
 };
-uuid.v1(v1options); // ⇨ '710b962e-041c-11e1-9234-0123456789ab'
+uuidv1(v1options); // ⇨ '710b962e-041c-11e1-9234-0123456789ab'
 
 ```
 
@@ -265,14 +264,14 @@ Example: In-place generation of two binary IDs
 ```javascript
 // Generate two ids in an array
 const arr = new Array();
-uuid.v1(null, arr, 0); // ⇨ 
+uuidv1(null, arr, 0); // ⇨ 
   // [
   //    44,  94, 164, 192,  64,
   //   103,  17, 233, 146,  52,
   //    27, 157, 107, 205, 187,
   //   253
   // ]
-uuid.v1(null, arr, 16); // ⇨ 
+uuidv1(null, arr, 16); // ⇨ 
   // [
   //    44, 94, 164, 192,  64, 103,  17, 233,
   //   146, 52,  27, 157, 107, 205, 187, 253,
@@ -285,12 +284,12 @@ uuid.v1(null, arr, 16); // ⇨
 ### Version 3 (Namespace)
 
 ```javascript
-const uuid = require('uuid');
+import { v3 as uuidv3 } from 'uuid';
 
 // Incantations
-uuid.v3(name, namespace);
-uuid.v3(name, namespace, buffer);
-uuid.v3(name, namespace, buffer, offset);
+uuidv3(name, namespace);
+uuidv3(name, namespace, buffer);
+uuidv3(name, namespace, buffer, offset);
 ```
 
 Generate and return a RFC4122 v3 UUID.
@@ -305,19 +304,19 @@ Returns `buffer`, if specified, otherwise the string form of the UUID
 Example:
 
 ```javascript
-uuid.v3('hello world', MY_NAMESPACE); // ⇨ '042ffd34-d989-321c-ad06-f60826172424'
+uuidv3('hello world', MY_NAMESPACE); // ⇨ '042ffd34-d989-321c-ad06-f60826172424'
 
 ```
 
 ### Version 5 (Namespace)
 
 ```javascript
-const uuid = require('uuid');
+import { v5 as uuidv5 } from 'uuid';
 
 // Incantations
-uuid.v5(name, namespace);
-uuid.v5(name, namespace, buffer);
-uuid.v5(name, namespace, buffer, offset);
+uuidv5(name, namespace);
+uuidv5(name, namespace, buffer);
+uuidv5(name, namespace, buffer, offset);
 ```
 
 Generate and return a RFC4122 v5 UUID.
@@ -332,7 +331,7 @@ Returns `buffer`, if specified, otherwise the string form of the UUID
 Example:
 
 ```javascript
-uuid.v5('hello world', MY_NAMESPACE); // ⇨ '9f282611-e0fd-5650-8953-89c8e342da0b'
+uuidv5('hello world', MY_NAMESPACE); // ⇨ '9f282611-e0fd-5650-8953-89c8e342da0b'
 
 ```
 

--- a/README_js.md
+++ b/README_js.md
@@ -52,12 +52,11 @@ import { v4 as uuidv4 } from 'uuid';
 uuidv4();
 ```
 
-For use as CommonJS module with Node.js (where bundlesize is no concern) just require the main
-package:
+For use as CommonJS module with Node.js you can use:
 
 ```javascript
-const uuid = require('uuid');
-uuid.v4();
+const { v4: uuidv4 } = require('uuid');
+uuidv4();
 ```
 
 ## Quickstart - Node.js/CommonJS
@@ -71,8 +70,8 @@ Then generate a random UUID (v4 algorithm), which is almost always what you want
 Version 4 (random):
 
 ```javascript --run v4
-const uuid = require('uuid');
-uuid.v4(); // RESULT
+import { v4 as uuidv4 } from 'uuid';
+uuidv4(); // RESULT
 ```
 
 Or generate UUIDs with other algorithms of your choice ...
@@ -80,46 +79,46 @@ Or generate UUIDs with other algorithms of your choice ...
 Version 1 (timestamp):
 
 ```javascript --run v1
-const uuid = require('uuid');
-uuid.v1(); // RESULT
+import { v1 as uuidv1 } from 'uuid';
+uuidv1(); // RESULT
 ```
 
 Version 3 (namespace):
 
 ```javascript --run v3
-const uuid = require('uuid');
+import { v3 as uuidv3 } from 'uuid';
 
 // ... using predefined DNS namespace (for domain names)
-uuid.v3('hello.example.com', uuid.v3.DNS); // RESULT
+uuidv3('hello.example.com', uuidv3.DNS); // RESULT
 
 // ... using predefined URL namespace (for, well, URLs)
-uuid.v3('http://example.com/hello', uuid.v3.URL); // RESULT
+uuidv3('http://example.com/hello', uuidv3.URL); // RESULT
 
 // ... using a custom namespace
 //
 // Note: Custom namespaces should be a UUID string specific to your application!
 // E.g. the one here was generated using this modules `uuid` CLI.
 const MY_NAMESPACE = '1b671a64-40d5-491e-99b0-da01ff1f3341';
-uuid.v3('Hello, World!', MY_NAMESPACE); // RESULT
+uuidv3('Hello, World!', MY_NAMESPACE); // RESULT
 ```
 
 Version 5 (namespace):
 
 ```javascript --run v5
-const uuid = require('uuid');
+import { v5 as uuidv5 } from 'uuid';
 
 // ... using predefined DNS namespace (for domain names)
-uuid.v5('hello.example.com', uuid.v5.DNS); // RESULT
+uuidv5('hello.example.com', uuidv5.DNS); // RESULT
 
 // ... using predefined URL namespace (for, well, URLs)
-uuid.v5('http://example.com/hello', uuid.v5.URL); // RESULT
+uuidv5('http://example.com/hello', uuidv5.URL); // RESULT
 
 // ... using a custom namespace
 //
 // Note: Custom namespaces should be a UUID string specific to your application!
 // E.g. the one here was generated using this modules `uuid` CLI.
 const MY_NAMESPACE = '1b671a64-40d5-491e-99b0-da01ff1f3341';
-uuid.v5('Hello, World!', MY_NAMESPACE); // RESULT
+uuidv5('Hello, World!', MY_NAMESPACE); // RESULT
 ```
 
 ## Supported Platforms
@@ -159,12 +158,12 @@ npm run build
 ### Version 4 (Random)
 
 ```javascript
-const uuid = require('uuid');
+import { v4 as uuidv4 } from 'uuid';
 
 // Incantations
-uuid.v4();
-uuid.v4(options);
-uuid.v4(options, buffer, offset);
+uuidv4();
+uuidv4(options);
+uuidv4(options, buffer, offset);
 ```
 
 Generate and return a RFC4122 v4 UUID.
@@ -200,15 +199,15 @@ const v4options = {
     0x36,
   ],
 };
-uuid.v4(v4options); // RESULT
+uuidv4(v4options); // RESULT
 ```
 
 Example: Generate two IDs in a single buffer
 
 ```javascript --run v4
 const buffer = new Array();
-uuid.v4(null, buffer, 0); // RESULT
-uuid.v4(null, buffer, 16); // RESULT
+uuidv4(null, buffer, 0); // RESULT
+uuidv4(null, buffer, 16); // RESULT
 ```
 
 ### Version 1 (Timestamp + Node)
@@ -218,12 +217,12 @@ before using them. In many cases, Version 4 random UUIDs are the better choice. 
 FAQ](https://github.com/tc39/proposal-uuid#faq) covers more details.** ⚠️⚠️⚠️
 
 ```javascript
-const uuid = require('uuid');
+import { v1 as uuidv1 } from 'uuid';
 
 // Incantations
-uuid.v1();
-uuid.v1(options);
-uuid.v1(options, buffer, offset);
+uuidv1();
+uuidv1(options);
+uuidv1(options, buffer, offset);
 ```
 
 Generate and return a RFC4122 v1 (timestamp-based) UUID.
@@ -251,7 +250,7 @@ const v1options = {
   msecs: new Date('2011-11-01').getTime(),
   nsecs: 5678,
 };
-uuid.v1(v1options); // RESULT
+uuidv1(v1options); // RESULT
 ```
 
 Example: In-place generation of two binary IDs
@@ -259,19 +258,19 @@ Example: In-place generation of two binary IDs
 ```javascript --run v1
 // Generate two ids in an array
 const arr = new Array();
-uuid.v1(null, arr, 0); // RESULT
-uuid.v1(null, arr, 16); // RESULT
+uuidv1(null, arr, 0); // RESULT
+uuidv1(null, arr, 16); // RESULT
 ```
 
 ### Version 3 (Namespace)
 
 ```javascript
-const uuid = require('uuid');
+import { v3 as uuidv3 } from 'uuid';
 
 // Incantations
-uuid.v3(name, namespace);
-uuid.v3(name, namespace, buffer);
-uuid.v3(name, namespace, buffer, offset);
+uuidv3(name, namespace);
+uuidv3(name, namespace, buffer);
+uuidv3(name, namespace, buffer, offset);
 ```
 
 Generate and return a RFC4122 v3 UUID.
@@ -286,18 +285,18 @@ Returns `buffer`, if specified, otherwise the string form of the UUID
 Example:
 
 ```javascript --run v3
-uuid.v3('hello world', MY_NAMESPACE); // RESULT
+uuidv3('hello world', MY_NAMESPACE); // RESULT
 ```
 
 ### Version 5 (Namespace)
 
 ```javascript
-const uuid = require('uuid');
+import { v5 as uuidv5 } from 'uuid';
 
 // Incantations
-uuid.v5(name, namespace);
-uuid.v5(name, namespace, buffer);
-uuid.v5(name, namespace, buffer, offset);
+uuidv5(name, namespace);
+uuidv5(name, namespace, buffer);
+uuidv5(name, namespace, buffer, offset);
 ```
 
 Generate and return a RFC4122 v5 UUID.
@@ -312,7 +311,7 @@ Returns `buffer`, if specified, otherwise the string form of the UUID
 Example:
 
 ```javascript --run v5
-uuid.v5('hello world', MY_NAMESPACE); // RESULT
+uuidv5('hello world', MY_NAMESPACE); // RESULT
 ```
 
 ## Command Line

--- a/package-lock.json
+++ b/package-lock.json
@@ -10231,9 +10231,8 @@
       "dev": true
     },
     "runmd": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/runmd/-/runmd-1.2.1.tgz",
-      "integrity": "sha512-X+PF3B7x0jyImxUrmx5PWoZiU3Mz4pc/ZH+SzsopSST3pQo1DXi0tCllJJI/ryCHYmfPLvA/9Fliw9Dg/Pu1NA==",
+      "version": "github:ctavan/runmd#cdeb284a3dc3c3b48b6626167058a2ea68987f7a",
+      "from": "github:ctavan/runmd#add-naive-import-support",
       "dev": true,
       "requires": {
         "minimist": "1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10231,8 +10231,9 @@
       "dev": true
     },
     "runmd": {
-      "version": "github:ctavan/runmd#cdeb284a3dc3c3b48b6626167058a2ea68987f7a",
-      "from": "github:ctavan/runmd#add-naive-import-support",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/runmd/-/runmd-1.3.2.tgz",
+      "integrity": "sha512-rSg5m3BpNuZ7k9zuaoq079SBKf/riiBCR3j4y7BprAgulyEWztm2vXkE44mqh17P2qQG9BWmmkUhhld8nG+CUA==",
       "dev": true,
       "requires": {
         "minimist": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "prettier": "1.19.1",
     "rollup": "1.30.0",
     "rollup-plugin-terser": "5.2.0",
-    "runmd": "1.2.1",
+    "runmd": "ctavan/runmd#add-naive-import-support",
     "selenium-webdriver": "3.6.0",
     "standard-version": "7.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "prettier": "1.19.1",
     "rollup": "1.30.0",
     "rollup-plugin-terser": "5.2.0",
-    "runmd": "ctavan/runmd#add-naive-import-support",
+    "runmd": "1.3.2",
     "selenium-webdriver": "3.6.0",
     "standard-version": "7.0.1"
   },


### PR DESCRIPTION
Especially for use in the browser modern ESModule import syntax is
preferable because it allows for proper treeshaking by bundlers like
Webpack/rollup.