### PR TITLE
docs: add note why v7.x follows the v3.x major release

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,12 @@ Features:
 ⚠️⚠️⚠️ This is the README of the upcoming major version of this library. You can still [access the README
 of the current stable version](https://github.com/uuidjs/uuid/blob/v3.4.0/README.md). ⚠️⚠️⚠️
 
-## Upgrading from v3.x of this Module
+## Upgrading from v3.x of this Library
+
+The latest major version of this library is v7.x and the previous major version was v3.x. We
+decided to jump v4.x, v5.x and v6.x in order to avoid any confusion with [version
+4](#version-4-random) and [version 5](#version-5-namespace) UUIDs and the [version 6 UUID
+proposal](http://gh.peabody.io/uuidv6/).
 
 In v3.x of this library we were promoting the use of deep requires to reduce bundlesize for browser
 builds:

--- a/README_js.md
+++ b/README_js.md
@@ -30,7 +30,12 @@ Features:
 ⚠️⚠️⚠️ This is the README of the upcoming major version of this library. You can still [access the README
 of the current stable version](https://github.com/uuidjs/uuid/blob/v3.4.0/README.md). ⚠️⚠️⚠️
 
-## Upgrading from v3.x of this Module
+## Upgrading from v3.x of this Library
+
+The latest major version of this library is v7.x and the previous major version was v3.x. We
+decided to jump v4.x, v5.x and v6.x in order to avoid any confusion with [version
+4](#version-4-random) and [version 5](#version-5-namespace) UUIDs and the [version 6 UUID
+proposal](http://gh.peabody.io/uuidv6/).
 
 In v3.x of this library we were promoting the use of deep requires to reduce bundlesize for browser
 builds:


### PR DESCRIPTION
Sorry, I messed up #369 … It had the wrong base branch (not master). Could you approve again, @broofa ?