### PR TITLE
docs: add note about removal of default export

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,13 @@ of the current stable version](https://github.com/uuidjs/uuid/blob/v3.4.0/README
 
 ## Upgrading from v3.x of this Module
 
+### Deep Requires now Deprecated
+
 In v3.x of this library we were promoting the use of deep requires to reduce bundlesize for browser
 builds:
 
 ```javascript
-const uuidv4 = require('uuid/v4');
+const uuidv4 = require('uuid/v4'); // <== NOW DEPRECATED!
 uuidv4();
 ```
 
@@ -45,6 +47,16 @@ For use as CommonJS module with Node.js you can use:
 const { v4: uuidv4 } = require('uuid');
 uuidv4();
 ```
+
+### Default Export Removed
+
+v3.x of this library was exporting the Version 4 UUID method as a default export:
+
+```javascript
+const uuid = require('uuid'); // <== REMOVED!
+```
+
+This usage pattern was already discouraged in v3.x and has been removed in v7.x.
 
 ## Quickstart - Node.js/CommonJS
 

--- a/README_js.md
+++ b/README_js.md
@@ -32,11 +32,13 @@ of the current stable version](https://github.com/uuidjs/uuid/blob/v3.4.0/README
 
 ## Upgrading from v3.x of this Module
 
+### Deep Requires now Deprecated
+
 In v3.x of this library we were promoting the use of deep requires to reduce bundlesize for browser
 builds:
 
 ```javascript
-const uuidv4 = require('uuid/v4');
+const uuidv4 = require('uuid/v4'); // <== NOW DEPRECATED!
 uuidv4();
 ```
 
@@ -58,6 +60,16 @@ For use as CommonJS module with Node.js you can use:
 const { v4: uuidv4 } = require('uuid');
 uuidv4();
 ```
+
+### Default Export Removed
+
+v3.x of this library was exporting the Version 4 UUID method as a default export:
+
+```javascript
+const uuid = require('uuid'); // <== REMOVED!
+```
+
+This usage pattern was already discouraged in v3.x and has been removed in v7.x.
 
 ## Quickstart - Node.js/CommonJS
 


### PR DESCRIPTION
BREAKING CHANGE: The default export, which used to be the v4() method
but which was already discouraged in v3.x of this library, has been
removed.

Fixes #370