### PR TITLE
docs: remove link to last stable version

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,6 @@ Features:
 - Uses cryptographically-strong random number APIs
 - Zero-dependency, small footprint
 
-⚠️⚠️⚠️ This is the README of the upcoming major version of this library. You can still [access the README
-of the current stable version](https://github.com/uuidjs/uuid/blob/v3.4.0/README.md). ⚠️⚠️⚠️
-
 ## Upgrading from v3.x of this Library
 
 The latest major version of this library is v7.x and the previous major version was v3.x. We

--- a/README_js.md
+++ b/README_js.md
@@ -27,9 +27,6 @@ Features:
 - Uses cryptographically-strong random number APIs
 - Zero-dependency, small footprint
 
-⚠️⚠️⚠️ This is the README of the upcoming major version of this library. You can still [access the README
-of the current stable version](https://github.com/uuidjs/uuid/blob/v3.4.0/README.md). ⚠️⚠️⚠️
-
 ## Upgrading from v3.x of this Library
 
 The latest major version of this library is v7.x and the previous major version was v3.x. We


### PR DESCRIPTION
@broofa this would be the last thing I'd merge before doing the 7.0.0 release.

So far we have received a little bit of feedback regarding the new release which was all positive:
- https://github.com/uuidjs/uuid/issues/368#issuecomment-587940059
- https://github.com/uuidjs/uuid/issues/245#issuecomment-587349211
- https://github.com/DefinitelyTyped/DefinitelyTyped/pull/42438#issuecomment-587437257

Would you prefer to wait a bit longer to collect feedback or just ship 7.0.0?