### PR TITLE
fix: provide browser versions independent from module system

### DIFF
--- a/examples/browser-rollup/rollup.config.js
+++ b/examples/browser-rollup/rollup.config.js
@@ -1,7 +1,7 @@
 const resolve = require('rollup-plugin-node-resolve');
 const { terser } = require('rollup-plugin-terser');
 
-const plugins = [resolve(), terser()];
+const plugins = [resolve({ browser: true }), terser()];
 module.exports = [
   {
     input: './example-all.js',

--- a/package-lock.json
+++ b/package-lock.json
@@ -3084,6 +3084,53 @@
         "rimraf": "^2.5.2"
       }
     },
+    "@rollup/plugin-node-resolve": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-7.1.1.tgz",
+      "integrity": "sha512-14ddhD7TnemeHE97a4rLOhobfYvUVcaYuqTnL8Ti7Jxi9V9Jr5LY7Gko4HZ5k4h4vqQM0gBQt6tsp9xXW94WPA==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.0.6",
+        "@types/resolve": "0.0.8",
+        "builtin-modules": "^3.1.0",
+        "is-module": "^1.0.0",
+        "resolve": "^1.14.2"
+      },
+      "dependencies": {
+        "builtin-modules": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.1.0.tgz",
+          "integrity": "sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw==",
+          "dev": true
+        },
+        "resolve": {
+          "version": "1.15.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
+          "integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        }
+      }
+    },
+    "@rollup/pluginutils": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.0.8.tgz",
+      "integrity": "sha512-rYGeAc4sxcZ+kPG/Tw4/fwJODC3IXHYDH4qusdN/b6aLw5LPUbzpecYbEJh4sVQGPFJxd2dBU4kc1H3oy9/bnw==",
+      "dev": true,
+      "requires": {
+        "estree-walker": "^1.0.1"
+      },
+      "dependencies": {
+        "estree-walker": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+          "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+          "dev": true
+        }
+      }
+    },
     "@samverschueren/stream-to-observable": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
@@ -3197,6 +3244,15 @@
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
+    },
+    "@types/resolve": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.8.tgz",
+      "integrity": "sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/stack-utils": {
       "version": "1.0.1",
@@ -7380,6 +7436,12 @@
       "requires": {
         "is-extglob": "^2.1.1"
       }
+    },
+    "is-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
+      "dev": true
     },
     "is-number": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,13 @@
   },
   "sideEffects": false,
   "main": "dist/index.js",
-  "module": "dist/esm-browser/index.js",
+  "module": "dist/esm-node/index.js",
+  "browser": {
+    "./dist/md5.js": "./dist/md5-browser.js",
+    "./dist/rng.js": "./dist/rng-browser.js",
+    "./dist/sha1.js": "./dist/sha1-browser.js",
+    "./dist/esm-node/index.js": "./dist/esm-browser/index.js"
+  },
   "files": [
     "CHANGELOG.md",
     "CONTRIBUTING.md",
@@ -36,6 +42,7 @@
     "@babel/preset-env": "7.8.4",
     "@commitlint/cli": "8.3.5",
     "@commitlint/config-conventional": "8.3.4",
+    "@rollup/plugin-node-resolve": "7.1.1",
     "babel-eslint": "10.0.3",
     "babel-plugin-add-module-exports": "1.0.2",
     "browserstack-local": "1.4.5",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,3 +1,4 @@
+import nodeResolve from '@rollup/plugin-node-resolve';
 import { terser } from 'rollup-plugin-terser';
 
 function chunk(input, name) {
@@ -9,7 +10,7 @@ function chunk(input, name) {
       name,
       compact: true,
     },
-    plugins: [terser()],
+    plugins: [nodeResolve({ browser: true }), terser()],
   };
 }
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -14,12 +14,17 @@ mkdir -p "$DIR"
 # Transpile CommonJS versions of files
 babel --env-name commonjs src --source-root src --out-dir "$DIR" --copy-files --quiet
 
-# Transpile ESM versions of files for the browser
+# Transpile ESM versions of files for browser
 babel --env-name esm src --source-root src --out-dir "$DIR/esm-browser" --copy-files --quiet
+
+# Transpile ESM versions of files for node
+babel --env-name esm src --source-root src --out-dir "$DIR/esm-node" --copy-files --quiet
 
 # No need to have the CLI files in the esm build
 rm -rf "$DIR/esm-browser/bin"
 rm -rf "$DIR/esm-browser/uuid-bin.js"
+rm -rf "$DIR/esm-node/bin"
+rm -rf "$DIR/esm-node/uuid-bin.js"
 
 for FILE in "$DIR"/esm-browser/*-browser.js
 do
@@ -28,7 +33,7 @@ do
 done
 
 echo "Removing browser-specific files from esm-node"
-rm -f "$DIR"/*-browser.js
+rm -f "$DIR"/esm-node/*-browser.js
 
 # UMD Build
 mkdir "$DIR/umd"


### PR DESCRIPTION
Probably will fix https://github.com/uuidjs/uuid/issues/378

Currently main field is used for node and module for browser build. This
is not entierly correct. Webpack can be used to build node apps. Though
module is always preferred over main. For browser versions there is a
special field.

In this diff I added esm support for both node and browser.
rollup-plugin-node-resolve look at browser field as well and prefer it
to bundle umd.