### PR TITLE
docs: add information on usage from React Native

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ versions, all of which are supported here. In order of popularity, they are:
 
 **Unsure which one to use?** Use version 4 (random) unless you have a specific need for one of the other versions. See also [this FAQ](https://github.com/tc39/proposal-uuid#faq).
 
+**Are you using React Native?** If you are using this library from React Native, you need to add a polyfill for `crypto.getRandomValues`. We recommend using [`react-native-get-random-values`](https://github.com/LinusU/react-native-get-random-values#readme).
+
 ### Create Version 4 (Random) UUIDs
 
 ```javascript

--- a/README_js.md
+++ b/README_js.md
@@ -48,6 +48,8 @@ versions, all of which are supported here. In order of popularity, they are:
 
 **Unsure which one to use?** Use version 4 (random) unless you have a specific need for one of the other versions. See also [this FAQ](https://github.com/tc39/proposal-uuid#faq).
 
+**Are you using React Native?** If you are using this library from React Native, you need to add a polyfill for `crypto.getRandomValues`. We recommend using [`react-native-get-random-values`](https://github.com/LinusU/react-native-get-random-values#readme).
+
 ### Create Version 4 (Random) UUIDs
 
 ```javascript --run v4


### PR DESCRIPTION
Closes #375

This adds information on how to get the library working on React Native to the readme.

-----

I've verified that this works by:

1. creating a new React Native project (`npx react-native init uuidtest`)
2. added the dependencies (`npm add react-native-get-random-values uuid`)
3. imported the polyfill (`import 'react-native-get-random-values'` in `index.js`)
4. and displayed an UUID in the app (`import * as uuid from 'uuid'` and `{uuid.v4()}` in `App.js`)