### PR TITLE
docs: make react native polyfill docs more explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,9 +341,15 @@ This error occurs in environments where the standard
 [`crypto.getRandomValues()`](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/getRandomValues)
 API is not supported. This issue can be resolved by adding an appropriate polyfill:
 
-| Environment  | Suggested Polyfill                                                                                  |
-| ------------ | --------------------------------------------------------------------------------------------------- |
-| React Native | [`react-native-get-random-values`](https://github.com/LinusU/react-native-get-random-values#readme) |
+### React Native
+
+1. Install [`react-native-get-random-values`](https://github.com/LinusU/react-native-get-random-values#readme)
+1. Import it before `uuid`:
+
+```javascript
+import 'react-native-get-random-values';
+import { v4 as uuidv4 } from 'uuid';
+```
 
 ## Upgrading From uuid\@3
 

--- a/README_js.md
+++ b/README_js.md
@@ -330,9 +330,15 @@ This error occurs in environments where the standard
 [`crypto.getRandomValues()`](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/getRandomValues)
 API is not supported. This issue can be resolved by adding an appropriate polyfill:
 
-| Environment  | Suggested Polyfill                                                                                  |
-| ------------ | --------------------------------------------------------------------------------------------------- |
-| React Native | [`react-native-get-random-values`](https://github.com/LinusU/react-native-get-random-values#readme) |
+### React Native
+
+1. Install [`react-native-get-random-values`](https://github.com/LinusU/react-native-get-random-values#readme)
+1. Import it before `uuid`:
+
+```javascript
+import 'react-native-get-random-values';
+import { v4 as uuidv4 } from 'uuid';
+```
 
 ## Upgrading From uuid\@3
 


### PR DESCRIPTION
I mostly agree with https://github.com/uuidjs/uuid/pull/390#issuecomment-593968052 and that we should not add a huge react native example just for the purpose of documentation.

However I think that we can still make our docs a bit more explicit with respect to how to apply the react native polyfill. I really liked the way nanoid are documenting this in their readme: https://github.com/ai/nanoid#react-native

I am _hoping_ by simply giving these two lines of example code (in the right import order) we can make the lives of react native users easier and reduce the amount of issues raised in this repo from people who just did not go the extra mile to check out the react-native-get-random-values docs.