### PR TITLE
docs: directly link to new react-native section

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ For the creation of [RFC4122](http://www.ietf.org/rfc/rfc4122.txt) UUIDs
   - Node 8, 10, 12
   - Chrome, Safari, Firefox, Edge, IE 11 browsers
   - Webpack and rollup.js module bundlers
-  - React Native ([see note](#getrandomvalues-not-supported))
+  - [React Native](#react-native)
 - **Secure** - Cryptographically-strong random values
 - **Small** - Zero-dependency, small footprint, plays nice with "tree shaking" packagers
 - **CLI** - Includes the [`uuid` command line](#command-line) utility

--- a/README_js.md
+++ b/README_js.md
@@ -25,7 +25,7 @@ For the creation of [RFC4122](http://www.ietf.org/rfc/rfc4122.txt) UUIDs
   - Node 8, 10, 12
   - Chrome, Safari, Firefox, Edge, IE 11 browsers
   - Webpack and rollup.js module bundlers
-  - React Native ([see note](#getrandomvalues-not-supported))
+  - [React Native](#react-native)
 - **Secure** - Cryptographically-strong random values
 - **Small** - Zero-dependency, small footprint, plays nice with "tree shaking" packagers
 - **CLI** - Includes the [`uuid` command line](#command-line) utility


### PR DESCRIPTION
Sorry for the noise. Missed that one in the original commit.