### PR TITLE
fix: make deep require deprecation warning work in browsers

### DIFF
--- a/deprecate.js
+++ b/deprecate.js
@@ -1,0 +1,20 @@
+// Extracted from: https://github.com/TooTallNate/util-deprecate
+let deprecate;
+try {
+  const util = require('util');
+  deprecate = util.deprecate;
+} catch (err) {
+  deprecate = function deprecate(fn, msg) {
+    var warned = false;
+    function deprecated() {
+      if (!warned) {
+        console.warn(msg);
+        warned = true;
+      }
+      return fn.apply(this, arguments);
+    }
+
+    return deprecated;
+  };
+}
+module.exports = deprecate;

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "CONTRIBUTING.md",
     "LICENSE.md",
     "README.md",
+    "deprecate.js",
     "dist",
     "v1.js",
     "v3.js",

--- a/v1.js
+++ b/v1.js
@@ -1,8 +1,8 @@
-const util = require('util');
+const deprecate = require('./deprecate.js');
 
 const v1 = require('./dist/v1.js');
 
-module.exports = util.deprecate(
+module.exports = deprecate(
   v1,
   "Deep requiring like `const uuidv1 = require('uuid/v1');` is deprecated as of uuid@7.x. Please require the top-level module when using the Node.js CommonJS module or use ECMAScript Modules when bundling for the browser. See https://github.com/uuidjs/uuid#deep-requires-now-deprecated for more information.",
 );

--- a/v3.js
+++ b/v3.js
@@ -1,8 +1,8 @@
-const util = require('util');
+const deprecate = require('./deprecate.js');
 
 const v3 = require('./dist/v3.js');
 
-module.exports = util.deprecate(
+module.exports = deprecate(
   v3,
   "Deep requiring like `const uuidv3 = require('uuid/v3');` is deprecated as of uuid@7.x. Please require the top-level module when using the Node.js CommonJS module or use ECMAScript Modules when bundling for the browser. See https://github.com/uuidjs/uuid#deep-requires-now-deprecated for more information.",
 );

--- a/v4.js
+++ b/v4.js
@@ -1,8 +1,8 @@
-const util = require('util');
+const deprecate = require('./deprecate.js');
 
 const v4 = require('./dist/v4.js');
 
-module.exports = util.deprecate(
+module.exports = deprecate(
   v4,
   "Deep requiring like `const uuidv4 = require('uuid/v4');` is deprecated as of uuid@7.x. Please require the top-level module when using the Node.js CommonJS module or use ECMAScript Modules when bundling for the browser. See https://github.com/uuidjs/uuid#deep-requires-now-deprecated for more information.",
 );

--- a/v5.js
+++ b/v5.js
@@ -1,8 +1,8 @@
-const util = require('util');
+const deprecate = require('./deprecate.js');
 
 const v5 = require('./dist/v5.js');
 
-module.exports = util.deprecate(
+module.exports = deprecate(
   v5,
   "Deep requiring like `const uuidv5 = require('uuid/v5');` is deprecated as of uuid@7.x. Please require the top-level module when using the Node.js CommonJS module or use ECMAScript Modules when bundling for the browser. See https://github.com/uuidjs/uuid#deep-requires-now-deprecated for more information.",
 );


### PR DESCRIPTION
Relates to #408

I used Node.js' `util.deprecate()` in order to print deprecation warnings for deep requires. This obviously doesn't work in the browser. This can be solved by providing a manual warning fallback for the browser:

![image](https://user-images.githubusercontent.com/508118/77932208-8422c000-72ad-11ea-8b01-311fb2606471.png)