### PR TITLE
feat: drop Node.js 8.x support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [10.x, 12.x]
 
     steps:
     - uses: actions/checkout@v1

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ For the creation of [RFC4122](http://www.ietf.org/rfc/rfc4122.txt) UUIDs
 - **Complete** - Support for RFC4122 version 1, 3, 4, and 5 UUIDs
 - **Cross-platform** - Support for ...
   - CommonJS, [ECMAScript Modules](#ecmascript-modules) and UMD builds
-  - Node 8, 10, 12
+  - Node.js LTS (10.x, 12.x)
   - Chrome, Safari, Firefox, Edge, IE 11 browsers
   - Webpack and rollup.js module bundlers
   - [React Native](#react-native)

--- a/README_js.md
+++ b/README_js.md
@@ -22,7 +22,7 @@ For the creation of [RFC4122](http://www.ietf.org/rfc/rfc4122.txt) UUIDs
 - **Complete** - Support for RFC4122 version 1, 3, 4, and 5 UUIDs
 - **Cross-platform** - Support for ...
   - CommonJS, [ECMAScript Modules](#ecmascript-modules) and UMD builds
-  - Node 8, 10, 12
+  - Node.js LTS (10.x, 12.x)
   - Chrome, Safari, Firefox, Edge, IE 11 browsers
   - Webpack and rollup.js module bundlers
   - [React Native](#react-native)


### PR DESCRIPTION
BREAKING CHANGE: Drop official support for Node.js 8.x since the 8.x
line has reached end-of-life on 2019-12-31. The library is likely to
continue to work with Node.js 8.x, we simply won't provide official
support for it.

Fixes #410.