### PR TITLE
test: always build using Node.js 12.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,13 @@ jobs:
     - uses: actions/checkout@v1
       with:
         fetch-depth: 10
+    - name: Use Node.js 12.x to build
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+    - run: npm install
+    - run: npm run build
+    - run: rm -rf node_modules
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "test:browser": "wdio run ./wdio.conf.js",
     "prettier:check": "prettier --ignore-path .prettierignore --check '**/*.{js,jsx,json,md}'",
     "prettier:fix": "prettier --ignore-path .prettierignore --write '**/*.{js,jsx,json,md}'",
-    "ci": "npm run lint && npm run test && npm run prettier:check && npm run docs:diff && npm run bundlewatch",
+    "ci": "npm run lint && npm run test && npm run docs:diff && npm run bundlewatch",
     "bundlewatch": "( node --version | grep -vq 'v12' ) || ( npm run pretest:browser && bundlewatch --config bundlewatch.config.json )",
     "md": "runmd --watch --output=README.md README_js.md",
     "docs": "( node --version | grep -q 'v12' ) && ( npm run build && runmd --output=README.md README_js.md )",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "lint": "npm run eslint:check && npm run prettier:check",
     "eslint:check": "eslint src/ test/ examples/ *.js",
     "eslint:fix": "eslint --fix src/ test/ examples/ *.js",
-    "pretest": "npm run build",
+    "pretest": "[ -n $CI ] || npm run build",
     "test": "BABEL_ENV=commonjs node --throw-deprecation node_modules/.bin/jest test/unit/",
     "pretest:browser": "npm run build && npm-run-all --parallel examples:**",
     "test:browser": "wdio run ./wdio.conf.js",


### PR DESCRIPTION
Always build using the latest supported Node.js version but then run the
CI with all Node.js versions that we want to support.