### PR TITLE
test: run certain parts of ci only on latest Node.js version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,14 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm install
-    - run: npm run ci
+    - run: npm run test
       env:
         CI: true
+    - run: npm run lint
+      if: matrix.node-version == '12.x'
+    - run: npm run docs:diff
+      if: matrix.node-version == '12.x'
+    - run: npm run bundlewatch
+      if: matrix.node-version == '12.x'
+      env:
         BUNDLEWATCH_GITHUB_TOKEN: ${{ secrets.BUNDLEWATCH_GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -80,11 +80,10 @@
     "test:browser": "wdio run ./wdio.conf.js",
     "prettier:check": "prettier --ignore-path .prettierignore --check '**/*.{js,jsx,json,md}'",
     "prettier:fix": "prettier --ignore-path .prettierignore --write '**/*.{js,jsx,json,md}'",
-    "ci": "npm run lint && npm run test && npm run docs:diff && npm run bundlewatch",
-    "bundlewatch": "( node --version | grep -vq 'v12' ) || ( npm run pretest:browser && bundlewatch --config bundlewatch.config.json )",
+    "bundlewatch": "npm run pretest:browser && bundlewatch --config bundlewatch.config.json",
     "md": "runmd --watch --output=README.md README_js.md",
     "docs": "( node --version | grep -q 'v12' ) && ( npm run build && runmd --output=README.md README_js.md )",
-    "docs:diff": "( node --version | grep -vq 'v12' ) || ( npm run docs && git diff --quiet README.md )",
+    "docs:diff": "npm run docs && git diff --quiet README.md",
     "build": "./scripts/build.sh",
     "release": "standard-version --no-verify"
   },


### PR DESCRIPTION
Instead of using complicated expressions in the package.json scripts
section, rather explicitly specify in the GitHub actions workflow
definitions which scripts should run on which Node.js version.