### PR TITLE
build: remove babel-plugin-add-module-exports

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -3,7 +3,6 @@ module.exports = {
   plugins: [],
   env: {
     commonjs: {
-      plugins: ['babel-plugin-add-module-exports'],
       presets: [['@babel/preset-env', { targets: { node: '8' }, modules: 'commonjs' }]],
     },
     esmBrowser: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3289,15 +3289,6 @@
         }
       }
     },
-    "babel-plugin-add-module-exports": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-add-module-exports/-/babel-plugin-add-module-exports-1.0.2.tgz",
-      "integrity": "sha512-4paN7RivvU3Rzju1vGSHWPjO8Y0rI6droWvSFKI6dvEQ4mvoV0zGojnlzVRfI6N8zISo6VERXt3coIuVmzuvNg==",
-      "dev": true,
-      "requires": {
-        "chokidar": "^2.0.4"
-      }
-    },
     "babel-plugin-dynamic-import-node": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "@wdio/static-server-service": "6.0.13",
     "@wdio/sync": "6.0.15",
     "babel-eslint": "10.1.0",
-    "babel-plugin-add-module-exports": "1.0.2",
     "bundlewatch": "0.2.6",
     "eslint": "6.8.0",
     "eslint-config-prettier": "6.10.1",

--- a/v1.js
+++ b/v1.js
@@ -1,6 +1,6 @@
 const deprecate = require('./deprecate.js');
 
-const v1 = require('./dist/v1.js');
+const { default: v1 } = require('./dist/v1.js');
 
 module.exports = deprecate(
   v1,

--- a/v3.js
+++ b/v3.js
@@ -1,6 +1,6 @@
 const deprecate = require('./deprecate.js');
 
-const v3 = require('./dist/v3.js');
+const { default: v3 } = require('./dist/v3.js');
 
 module.exports = deprecate(
   v3,

--- a/v4.js
+++ b/v4.js
@@ -1,6 +1,6 @@
 const deprecate = require('./deprecate.js');
 
-const v4 = require('./dist/v4.js');
+const { default: v4 } = require('./dist/v4.js');
 
 module.exports = deprecate(
   v4,

--- a/v5.js
+++ b/v5.js
@@ -1,6 +1,6 @@
 const deprecate = require('./deprecate.js');
 
-const v5 = require('./dist/v5.js');
+const { default: v5 } = require('./dist/v5.js');
 
 module.exports = deprecate(
   v5,


### PR DESCRIPTION
Since we have deprecated deep requires we no longer need the module.exports from the individual v*.js files.

Since we now ship plain, non-babled deep require files on the top level of the npm package for legacy CommonJS deep-require support we can compensate for the lack of module.exports in there and instead simply access the "default" export of the algorithm-specific modules.

This change was inspired by https://github.com/webpack/webpack/issues/7973#issuecomment-417931938

----

I stumbled upon this one on my struggle to finally make some progress on #402. While this doesn't help with #402 it's certainly no longer necessary and anything we can do to simplify our build pipeline is always welcome I guess.