### PR TITLE
test: test imports with npm package contents

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,5 @@ jobs:
         BUNDLEWATCH_GITHUB_TOKEN: ${{ secrets.BUNDLEWATCH_GITHUB_TOKEN }}
     - run: npm run test:node
       if: matrix.node-version == '12.x' || matrix.node-version == '14.x'
+    - run: npm run test:pack
+      if: matrix.node-version == '14.x'

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 # Browserstack
 browserstack.err
 local.log
+*.tgz

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "test:browser": "wdio run ./wdio.conf.js",
     "pretest:node": "npm run build",
     "test:node": "npm-run-all --parallel examples:node:**",
+    "test:pack": "./scripts/testpack.sh",
     "prettier:check": "prettier --ignore-path .prettierignore --check '**/*.{js,jsx,json,md}'",
     "prettier:fix": "prettier --ignore-path .prettierignore --write '**/*.{js,jsx,json,md}'",
     "bundlewatch": "npm run pretest:browser && bundlewatch --config bundlewatch.config.json",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "docs": "( node --version | grep -q 'v12' ) && ( npm run build && runmd --output=README.md README_js.md )",
     "docs:diff": "npm run docs && git diff --quiet README.md",
     "build": "./scripts/build.sh",
+    "prepack": "npm run build",
     "release": "standard-version --no-verify"
   },
   "repository": {
@@ -114,8 +115,7 @@
   },
   "standard-version": {
     "scripts": {
-      "postchangelog": "prettier --write CHANGELOG.md",
-      "postcommit": "npm run build"
+      "postchangelog": "prettier --write CHANGELOG.md"
     }
   }
 }

--- a/scripts/testpack.sh
+++ b/scripts/testpack.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -eu
+
+# cd to the root dir
+ROOT="$(pwd)/$(dirname "$0")/.."
+cd "$ROOT" || exit 1
+
+npm pack
+
+mkdir -p ../test-pack
+
+cp examples/node-commonjs/example.js ../test-pack/commonjs.js
+cp examples/node-esmodules/example.mjs ../test-pack/esmodules.mjs
+
+cd ../test-pack
+
+npm init -y
+
+npm install ../uuid/uuid-*.tgz
+
+node commonjs.js
+node esmodules.mjs


### PR DESCRIPTION
Especially for publishing CommonJS/ESM/Browser dual packages a lot can go wrong in the actual build and release step, see: https://medium.com/javascript-in-plain-english/is-promise-post-mortem-cab807f18dcc

In order to catch regressions with respect to the supported ways of importing this library it makes sense to test this using `npm pack`.

Fixes #424