### PR TITLE
feat: improved bytesToUuid func

### DIFF
--- a/examples/benchmark/benchmark.js
+++ b/examples/benchmark/benchmark.js
@@ -9,7 +9,12 @@ const uuidv5 = (typeof window !== 'undefined' && window.uuidv5) || require('uuid
 console.log('Starting. Tests take ~1 minute to run ...');
 
 const array = new Array(16);
-const suite = new Benchmark.Suite();
+
+const suite = new Benchmark.Suite({
+  onError(event) {
+    console.error(event.target.error);
+  },
+});
 
 suite
   .add('uuidv1()', function () {

--- a/src/bytesToUuid.js
+++ b/src/bytesToUuid.js
@@ -14,28 +14,28 @@ function bytesToUuid(buf, offset) {
   const bth = byteToHex;
 
   // join used to fix memory issue caused by concatenation: https://bugs.chromium.org/p/v8/issues/detail?id=3175#c4
-  return [
-    bth[buf[i + 0]],
-    bth[buf[i + 1]],
-    bth[buf[i + 2]],
-    bth[buf[i + 3]],
-    '-',
-    bth[buf[i + 4]],
-    bth[buf[i + 5]],
-    '-',
-    bth[buf[i + 6]],
-    bth[buf[i + 7]],
-    '-',
-    bth[buf[i + 8]],
-    bth[buf[i + 9]],
-    '-',
-    bth[buf[i + 10]],
-    bth[buf[i + 11]],
-    bth[buf[i + 12]],
-    bth[buf[i + 13]],
-    bth[buf[i + 14]],
-    bth[buf[i + 15]],
-  ].join('');
+  return (
+    bth[buf[i + 0]] +
+    bth[buf[i + 1]] +
+    bth[buf[i + 2]] +
+    bth[buf[i + 3]] +
+    '-' +
+    bth[buf[i + 4]] +
+    bth[buf[i + 5]] +
+    '-' +
+    bth[buf[i + 6]] +
+    bth[buf[i + 7]] +
+    '-' +
+    bth[buf[i + 8]] +
+    bth[buf[i + 9]] +
+    '-' +
+    bth[buf[i + 10]] +
+    bth[buf[i + 11]] +
+    bth[buf[i + 12]] +
+    bth[buf[i + 13]] +
+    bth[buf[i + 14]] +
+    bth[buf[i + 15]]
+  ).toLowerCase();
 }
 
 export default bytesToUuid;

--- a/src/bytesToUuid.js
+++ b/src/bytesToUuid.js
@@ -13,7 +13,9 @@ function bytesToUuid(buf, offset) {
 
   const bth = byteToHex;
 
-  // join used to fix memory issue caused by concatenation: https://bugs.chromium.org/p/v8/issues/detail?id=3175#c4
+  // Note: Be careful editing this code!  It's been tuned for performance
+  // and works in ways you may not expect. See https://github.com/uuidjs/uuid/pull/434
+  // `toLowerCase` used to fix memory issue caused by concatenation: https://bugs.chromium.org/p/v8/issues/detail?id=3175#c4
   return (
     bth[buf[i + 0]] +
     bth[buf[i + 1]] +

--- a/src/bytesToUuid.js
+++ b/src/bytesToUuid.js
@@ -15,7 +15,6 @@ function bytesToUuid(buf, offset) {
 
   // Note: Be careful editing this code!  It's been tuned for performance
   // and works in ways you may not expect. See https://github.com/uuidjs/uuid/pull/434
-  // `toLowerCase` used to fix memory issue caused by concatenation: https://bugs.chromium.org/p/v8/issues/detail?id=3175#c4
   return (
     bth[buf[i + 0]] +
     bth[buf[i + 1]] +


### PR DESCRIPTION
I replaced the conversion of bytes to uuid with a more efficient way (and without inflating the size of the resulting string).

Here's what I got in terms of performance.

Benchmark master:

```
uuidv1() x 1,439,640 ops/sec ±0.91% (93 runs sampled)
uuidv1() fill existing array x 7,449,049 ops/sec ±0.55% (90 runs sampled)
uuidv4() x 349,506 ops/sec ±0.88% (90 runs sampled)
uuidv4() fill existing array x 404,741 ops/sec ±1.62% (90 runs sampled)
uuidv3() x 141,296 ops/sec ±0.79% (90 runs sampled)
uuidv5() x 142,066 ops/sec ±0.87% (92 runs sampled)
```

Benchmark this branch:

```
uuidv1() x 1,638,366 ops/sec ±1.07% (92 runs sampled)
uuidv1() fill existing array x 7,837,067 ops/sec ±0.68% (92 runs sampled)
uuidv4() x 394,752 ops/sec ±1.09% (90 runs sampled)
uuidv4() fill existing array x 412,690 ops/sec ±1.30% (91 runs sampled)
uuidv3() x 155,735 ops/sec ±0.72% (91 runs sampled)
uuidv5() x 152,023 ops/sec ±0.90% (89 runs sampled)
```