### PR TITLE
feat: improved v4 performance

### DIFF
--- a/README_js.md
+++ b/README_js.md
@@ -8,9 +8,8 @@ runmd.onRequire = (path) => {
 runmd.Date.now = () => 1551914748172;
 
 let seed = 0xdefaced;
-require('crypto').randomBytes = function () {
-  const a = [];
-  for (let i = 0; i < 16; i++) a.push((seed = (seed * 0x41a7) & 0x7fffffff) & 0xff);
+require('crypto').randomFillSync = function (a) {
+  for (let i = 0; i < 16; i++) a[i] = (seed = (seed * 0x41a7) & 0x7fffffff) & 0xff;
   return a;
 };
 ```

--- a/src/rng.js
+++ b/src/rng.js
@@ -1,5 +1,7 @@
 import crypto from 'crypto';
 
+const rnds8 = new Uint8Array(16);
+
 export default function rng() {
-  return crypto.randomBytes(16);
+  return crypto.randomFillSync(rnds8);
 }

--- a/src/v4.js
+++ b/src/v4.js
@@ -2,10 +2,10 @@ import rng from './rng.js';
 import bytesToUuid from './bytesToUuid.js';
 
 function v4(options, buf, offset) {
-  const i = (buf && offset) || 0;
+  const start = (buf && offset) || 0;
 
   if (typeof options === 'string') {
-    buf = options === 'binary' ? new Uint32Array(16) : null;
+    buf = options === 'binary' ? new Uint8Array(16) : null;
     options = null;
   }
 
@@ -19,12 +19,14 @@ function v4(options, buf, offset) {
 
   // Copy bytes to buffer, if provided
   if (buf) {
-    for (let ii = 0; ii < 16; ++ii) {
-      buf[i + ii] = rnds[ii];
+    for (let i = 0; i < 16; ++i) {
+      buf[start + i] = rnds[i];
     }
+
+    return buf;
   }
 
-  return buf || bytesToUuid(rnds);
+  return bytesToUuid(rnds);
 }
 
 export default v4;

--- a/src/v4.js
+++ b/src/v4.js
@@ -2,8 +2,6 @@ import rng from './rng.js';
 import bytesToUuid from './bytesToUuid.js';
 
 function v4(options, buf, offset) {
-  const start = (buf && offset) || 0;
-
   if (typeof options === 'string') {
     buf = options === 'binary' ? new Uint8Array(16) : null;
     options = null;
@@ -19,6 +17,8 @@ function v4(options, buf, offset) {
 
   // Copy bytes to buffer, if provided
   if (buf) {
+    const start = offset || 0;
+
     for (let i = 0; i < 16; ++i) {
       buf[start + i] = rnds[i];
     }

--- a/test/unit/v4.test.js
+++ b/test/unit/v4.test.js
@@ -45,13 +45,14 @@ describe('v4', () => {
 
   test('fills one UUID into a buffer as expected', () => {
     const buffer = [];
-    v4(
+    const result = v4(
       {
         random: randomBytesFixture,
       },
       buffer,
     );
     assert.deepEqual(buffer, expectedBytes);
+    assert.strictEqual(buffer, result);
   });
 
   test('fills two UUIDs into a buffer as expected', () => {


### PR DESCRIPTION
Performance is increased by using a single `rnds8` buffer to generate random numbers (as in browser version).

Changes affect only the `v1` and `v4`.

Benchmark master:

```
uuidv1() x 1,640,551 ops/sec ±0.76% (91 runs sampled)
uuidv1() fill existing array x 7,369,911 ops/sec ±0.49% (96 runs sampled)
uuidv4() x 389,271 ops/sec ±1.39% (92 runs sampled)
uuidv4() fill existing array x 407,681 ops/sec ±1.62% (91 runs sampled)
uuidv3() x 142,615 ops/sec ±0.81% (87 runs sampled)
uuidv5() x 141,386 ops/sec ±1.09% (87 runs sampled)
```

Benchmark this branch:

```
uuidv1() x 1,653,982 ops/sec ±0.91% (90 runs sampled)
uuidv1() fill existing array x 7,383,926 ops/sec ±0.66% (93 runs sampled)
uuidv4() x 471,989 ops/sec ±0.53% (93 runs sampled)
uuidv4() fill existing array x 484,766 ops/sec ±0.48% (96 runs sampled)
uuidv3() x 141,146 ops/sec ±1.18% (85 runs sampled)
uuidv5() x 147,054 ops/sec ±1.13% (90 runs sampled)
```