### PR TITLE
test: add tests for buffer api

### DIFF
--- a/test/unit/v1.test.js
+++ b/test/unit/v1.test.js
@@ -67,14 +67,16 @@ describe('v1', () => {
     );
   });
 
+  const fullOptions = {
+    msecs: 1321651533573,
+    nsecs: 5432,
+    clockseq: 0x385c,
+    node: [0x61, 0xcd, 0x3c, 0xbb, 0x32, 0x10],
+  };
+
   test('explicit options product expected id', () => {
     // Verify explicit options produce expected id
-    const id = v1({
-      msecs: 1321651533573,
-      nsecs: 5432,
-      clockseq: 0x385c,
-      node: [0x61, 0xcd, 0x3c, 0xbb, 0x32, 0x10],
-    });
+    const id = v1(fullOptions);
     assert(id === 'd9428888-122b-11e1-b85c-61cd3cbb3210', 'Explicit options produce expected id');
   });
 
@@ -87,5 +89,21 @@ describe('v1', () => {
     const after = u1.split('-')[0];
     const dt = parseInt(after, 16) - parseInt(before, 16);
     assert(dt === 1, 'Ids spanning 1ms boundary are 100ns apart');
+  });
+
+  const expectedBytes = [217, 66, 136, 136, 18, 43, 17, 225, 184, 92, 97, 205, 60, 187, 50, 16];
+
+  test('fills one UUID into a buffer as expected', () => {
+    const buffer = [];
+    const result = v1(fullOptions, buffer);
+    assert.deepEqual(buffer, expectedBytes);
+    assert.strictEqual(buffer, result);
+  });
+
+  test('fills two UUIDs into a buffer as expected', () => {
+    const buffer = [];
+    v1(fullOptions, buffer, 0);
+    v1(fullOptions, buffer, 16);
+    assert.deepEqual(buffer, expectedBytes.concat(expectedBytes));
   });
 });

--- a/test/unit/v35.test.js
+++ b/test/unit/v35.test.js
@@ -95,14 +95,10 @@ describe('v5', () => {
       0xf6,
     ];
 
-    v3('hello.example.com', v3.DNS, buf);
+    const result = v3('hello.example.com', v3.DNS, buf);
 
-    assert.ok(
-      buf.length === testBuf.length &&
-        buf.every(function (elem, idx) {
-          return elem === testBuf[idx];
-        }),
-    );
+    assert.deepEqual(buf, testBuf);
+    assert.strictEqual(result, buf);
 
     // test offsets as well
     buf = new Array(19);
@@ -113,13 +109,7 @@ describe('v5', () => {
 
     v3('hello.example.com', v3.DNS, buf, 3);
 
-    assert.ok(
-      buf.length === testBuf.length + 3 &&
-        buf.every(function (elem, idx) {
-          return idx >= 3 ? elem === testBuf[idx - 3] : elem === 'landmaster';
-        }),
-      'hello',
-    );
+    assert.deepEqual(buf, ['landmaster', 'landmaster', 'landmaster'].concat(testBuf));
   });
 
   test('v5', () => {
@@ -153,13 +143,9 @@ describe('v5', () => {
       0xec,
     ];
 
-    v5('hello.example.com', v5.DNS, buf);
-    assert.ok(
-      buf.length === testBuf.length &&
-        buf.every(function (elem, idx) {
-          return elem === testBuf[idx];
-        }),
-    );
+    const result = v5('hello.example.com', v5.DNS, buf);
+    assert.deepEqual(buf, testBuf);
+    assert.strictEqual(result, buf);
 
     // test offsets as well
     buf = new Array(19);
@@ -170,12 +156,7 @@ describe('v5', () => {
 
     v5('hello.example.com', v5.DNS, buf, 3);
 
-    assert.ok(
-      buf.length === testBuf.length + 3 &&
-        buf.every(function (elem, idx) {
-          return idx >= 3 ? elem === testBuf[idx - 3] : elem === 'landmaster';
-        }),
-    );
+    assert.deepEqual(buf, ['landmaster', 'landmaster', 'landmaster'].concat(testBuf));
   });
 
   test('v3/v5 constants', () => {


### PR DESCRIPTION
* Simplify the v3/v5 tests for the buffer api
* Add test cases to v1/v3/v5 to ensure that if passing a buffer as
  second parameter that buffer is not only filled but also returned. For
  v4 this has already been added in #435.

<!--
Thank you for your contribution!

If your pull request contains considerable changes please run the benchmark before and after your
changes and include the results in the pull request description. To run the benchmark execute:

    npm run test:benchmark

from the root of this repository.
-->
