### PR TITLE
feat: improved v35 performance

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,6 +13,12 @@
   },
   "parser": "babel-eslint",
   "rules": {
-    "no-var": ["error"]
+    "no-var": ["error"],
+    "no-empty": [
+      "error",
+      {
+        "allowEmptyCatch": true
+      }
+    ]
   }
 }

--- a/src/v35.js
+++ b/src/v35.js
@@ -6,11 +6,11 @@ function hexSymToDecNum(n) {
     return n - 48;
   }
   // ----------- A -------- F
-  else if (n >= 65 && n <= 70) {
+  if (n >= 65 && n <= 70) {
     return n - 55;
   }
   // ----------- a -------- f
-  else if (n >= 97 && n <= 102) {
+  if (n >= 97 && n <= 102) {
     return n - 87;
   }
 
@@ -23,30 +23,32 @@ function hexSymToDecNum(n) {
 function uuidToBytes(uuid) {
   const bytes = [];
 
-  if (uuid.length === 36) {
-    for (let i = 0; i < uuid.length; ++i) {
-      let h = uuid.charCodeAt(i);
+  if (uuid.length !== 36) {
+    return bytes;
+  }
 
-      if (i === 8 || i === 13 || i === 18 || i === 23) {
-        // ----- '-'
-        if (h === 45) {
-          continue;
-        } else {
-          return [];
-        }
-      }
+  for (let i = 0; i < 36; ++i) {
+    let h = uuid.charCodeAt(i);
 
-      const l = hexSymToDecNum(uuid.charCodeAt(i + 1));
-      h = hexSymToDecNum(h);
-
-      if (l === -1 || h === -1) {
+    if (i === 8 || i === 13 || i === 18 || i === 23) {
+      // ----- '-'
+      if (h === 45) {
+        continue;
+      } else {
         return [];
       }
-
-      bytes.push(h * 16 + l);
-
-      ++i;
     }
+
+    const l = hexSymToDecNum(uuid.charCodeAt(i + 1));
+    h = hexSymToDecNum(h);
+
+    if (l === -1 || h === -1) {
+      return [];
+    }
+
+    bytes.push(h * 16 + l);
+
+    ++i;
   }
 
   return bytes;

--- a/test/unit/v35.test.js
+++ b/test/unit/v35.test.js
@@ -96,7 +96,7 @@ describe('v5', () => {
     );
   });
 
-  test('v3 namespace validation', () => {
+  test('v3 namespace string validation', () => {
     assert.throws(() => {
       v3('hello.example.com', 'zyxwvuts-rqpo-nmlk-jihg-fedcba000000');
     });
@@ -105,6 +105,10 @@ describe('v5', () => {
       v3('hello.example.com', 'invalid uuid value');
     });
 
+    assert.ok(v3('hello.example.com', '00000000-0000-0000-0000-000000000000'));
+  });
+
+  test('v3 namespace buffer validation', () => {
     assert.throws(() => {
       v3('hello.example.com', new Array(15));
     });
@@ -112,9 +116,11 @@ describe('v5', () => {
     assert.throws(() => {
       v3('hello.example.com', new Array(17));
     });
+
+    assert.ok(v3('hello.example.com', new Array(16).fill(0)));
   });
 
-  test('v3 buffer', () => {
+  test('v3 fill buffer', () => {
     let buf = new Array(16);
 
     const testBuf = [
@@ -186,7 +192,7 @@ describe('v5', () => {
     );
   });
 
-  test('v5 namespace validation', () => {
+  test('v5 namespace string validation', () => {
     assert.throws(() => {
       v5('hello.example.com', 'zyxwvuts-rqpo-nmlk-jihg-fedcba000000');
     });
@@ -195,6 +201,10 @@ describe('v5', () => {
       v5('hello.example.com', 'invalid uuid value');
     });
 
+    assert.ok(v5('hello.example.com', '00000000-0000-0000-0000-000000000000'));
+  });
+
+  test('v5 namespace buffer validation', () => {
     assert.throws(() => {
       v5('hello.example.com', new Array(15));
     });
@@ -202,9 +212,11 @@ describe('v5', () => {
     assert.throws(() => {
       v5('hello.example.com', new Array(17));
     });
+
+    assert.ok(v5('hello.example.com', new Array(16).fill(0)));
   });
 
-  test('v5 buffer', () => {
+  test('v5 fill buffer', () => {
     let buf = new Array(16);
 
     const testBuf = [

--- a/test/unit/v35.test.js
+++ b/test/unit/v35.test.js
@@ -66,14 +66,55 @@ describe('v5', () => {
 
   test('v3', () => {
     // Expect to get the same results as http://tools.adjet.org/uuid-v3
-    assert.equal(v3('hello.example.com', v3.DNS), '9125a8dc-52ee-365b-a5aa-81b0b3681cf6');
-    assert.equal(v3('http://example.com/hello', v3.URL), 'c6235813-3ba4-3801-ae84-e0a6ebb7d138');
-    assert.equal(
+    assert.strictEqual(v3('hello.example.com', v3.DNS), '9125a8dc-52ee-365b-a5aa-81b0b3681cf6');
+
+    assert.strictEqual(
+      v3('http://example.com/hello', v3.URL),
+      'c6235813-3ba4-3801-ae84-e0a6ebb7d138',
+    );
+
+    assert.strictEqual(
+      v3('hello', '0f5abcd1-c194-47f3-905b-2df7263a084b'),
+      'a981a0c2-68b1-35dc-bcfc-296e52ab01ec',
+    );
+  });
+
+  test('v3 namespace.toUpperCase', () => {
+    assert.strictEqual(
+      v3('hello.example.com', v3.DNS.toUpperCase()),
+      '9125a8dc-52ee-365b-a5aa-81b0b3681cf6',
+    );
+
+    assert.strictEqual(
+      v3('http://example.com/hello', v3.URL.toUpperCase()),
+      'c6235813-3ba4-3801-ae84-e0a6ebb7d138',
+    );
+
+    assert.strictEqual(
       v3('hello', '0f5abcd1-c194-47f3-905b-2df7263a084b'.toUpperCase()),
       'a981a0c2-68b1-35dc-bcfc-296e52ab01ec',
     );
+  });
 
-    // test the buffer functionality
+  test('v3 namespace validation', () => {
+    assert.throws(() => {
+      v3('hello.example.com', 'zyxwvuts-rqpo-nmlk-jihg-fedcba000000');
+    });
+
+    assert.throws(() => {
+      v3('hello.example.com', 'invalid uuid value');
+    });
+
+    assert.throws(() => {
+      v3('hello.example.com', new Array(15));
+    });
+
+    assert.throws(() => {
+      v3('hello.example.com', new Array(17));
+    });
+  });
+
+  test('v3 buffer', () => {
     let buf = new Array(16);
 
     const testBuf = [
@@ -120,28 +161,60 @@ describe('v5', () => {
         }),
       'hello',
     );
-
-    let invalid = false;
-
-    try {
-      v3('hello.example.com', 'zyzwvuts-rqp0-nmlk-jihg-fedcba000000');
-    } catch (err) {
-      invalid = true;
-    }
-
-    assert.ok(invalid, 'v3 namespace should be invalid');
   });
 
   test('v5', () => {
     // Expect to get the same results as http://tools.adjet.org/uuid-v5
-    assert.equal(v5('hello.example.com', v5.DNS), 'fdda765f-fc57-5604-a269-52a7df8164ec');
-    assert.equal(v5('http://example.com/hello', v5.URL), '3bbcee75-cecc-5b56-8031-b6641c1ed1f1');
-    assert.equal(
+    assert.strictEqual(v5('hello.example.com', v5.DNS), 'fdda765f-fc57-5604-a269-52a7df8164ec');
+
+    assert.strictEqual(
+      v5('http://example.com/hello', v5.URL),
+      '3bbcee75-cecc-5b56-8031-b6641c1ed1f1',
+    );
+
+    assert.strictEqual(
+      v5('hello', '0f5abcd1-c194-47f3-905b-2df7263a084b'),
+      '90123e1c-7512-523e-bb28-76fab9f2f73d',
+    );
+  });
+
+  test('v5 namespace.toUpperCase', () => {
+    // Expect to get the same results as http://tools.adjet.org/uuid-v5
+    assert.strictEqual(
+      v5('hello.example.com', v5.DNS.toUpperCase()),
+      'fdda765f-fc57-5604-a269-52a7df8164ec',
+    );
+
+    assert.strictEqual(
+      v5('http://example.com/hello', v5.URL.toUpperCase()),
+      '3bbcee75-cecc-5b56-8031-b6641c1ed1f1',
+    );
+
+    assert.strictEqual(
       v5('hello', '0f5abcd1-c194-47f3-905b-2df7263a084b'.toUpperCase()),
       '90123e1c-7512-523e-bb28-76fab9f2f73d',
     );
+  });
 
-    // test the buffer functionality
+  test('v5 namespace validation', () => {
+    assert.throws(() => {
+      v5('hello.example.com', 'zyxwvuts-rqpo-nmlk-jihg-fedcba000000');
+    });
+
+    assert.throws(() => {
+      v5('hello.example.com', 'invalid uuid value');
+    });
+
+    assert.throws(() => {
+      v5('hello.example.com', new Array(15));
+    });
+
+    assert.throws(() => {
+      v5('hello.example.com', new Array(17));
+    });
+  });
+
+  test('v5 buffer', () => {
     let buf = new Array(16);
 
     const testBuf = [
@@ -164,6 +237,7 @@ describe('v5', () => {
     ];
 
     v5('hello.example.com', v5.DNS, buf);
+
     assert.ok(
       buf.length === testBuf.length &&
         buf.every(function (elem, idx) {
@@ -186,22 +260,12 @@ describe('v5', () => {
           return idx >= 3 ? elem === testBuf[idx - 3] : elem === 'landmaster';
         }),
     );
-
-    let invalid = false;
-
-    try {
-      v5('hello.example.com', 'invalid uuid value');
-    } catch (err) {
-      invalid = true;
-    }
-
-    assert.ok(invalid, 'v5 namespace should be invalid');
   });
 
   test('v3/v5 constants', () => {
-    assert.equal(v3.DNS, '6ba7b810-9dad-11d1-80b4-00c04fd430c8');
-    assert.equal(v3.URL, '6ba7b811-9dad-11d1-80b4-00c04fd430c8');
-    assert.equal(v5.DNS, '6ba7b810-9dad-11d1-80b4-00c04fd430c8');
-    assert.equal(v5.URL, '6ba7b811-9dad-11d1-80b4-00c04fd430c8');
+    assert.strictEqual(v3.DNS, '6ba7b810-9dad-11d1-80b4-00c04fd430c8');
+    assert.strictEqual(v3.URL, '6ba7b811-9dad-11d1-80b4-00c04fd430c8');
+    assert.strictEqual(v5.DNS, '6ba7b810-9dad-11d1-80b4-00c04fd430c8');
+    assert.strictEqual(v5.URL, '6ba7b811-9dad-11d1-80b4-00c04fd430c8');
   });
 });

--- a/test/unit/v35.test.js
+++ b/test/unit/v35.test.js
@@ -69,7 +69,7 @@ describe('v5', () => {
     assert.equal(v3('hello.example.com', v3.DNS), '9125a8dc-52ee-365b-a5aa-81b0b3681cf6');
     assert.equal(v3('http://example.com/hello', v3.URL), 'c6235813-3ba4-3801-ae84-e0a6ebb7d138');
     assert.equal(
-      v3('hello', '0f5abcd1-c194-47f3-905b-2df7263a084b'),
+      v3('hello', '0f5abcd1-c194-47f3-905b-2df7263a084b'.toUpperCase()),
       'a981a0c2-68b1-35dc-bcfc-296e52ab01ec',
     );
 
@@ -120,6 +120,16 @@ describe('v5', () => {
         }),
       'hello',
     );
+
+    let invalid = false;
+
+    try {
+      v3('hello.example.com', 'zyzwvuts-rqp0-nmlk-jihg-fedcba000000');
+    } catch (err) {
+      invalid = true;
+    }
+
+    assert.ok(invalid, 'v3 namespace should be invalid');
   });
 
   test('v5', () => {
@@ -127,7 +137,7 @@ describe('v5', () => {
     assert.equal(v5('hello.example.com', v5.DNS), 'fdda765f-fc57-5604-a269-52a7df8164ec');
     assert.equal(v5('http://example.com/hello', v5.URL), '3bbcee75-cecc-5b56-8031-b6641c1ed1f1');
     assert.equal(
-      v5('hello', '0f5abcd1-c194-47f3-905b-2df7263a084b'),
+      v5('hello', '0f5abcd1-c194-47f3-905b-2df7263a084b'.toUpperCase()),
       '90123e1c-7512-523e-bb28-76fab9f2f73d',
     );
 
@@ -176,6 +186,16 @@ describe('v5', () => {
           return idx >= 3 ? elem === testBuf[idx - 3] : elem === 'landmaster';
         }),
     );
+
+    let invalid = false;
+
+    try {
+      v5('hello.example.com', 'invalid uuid value');
+    } catch (err) {
+      invalid = true;
+    }
+
+    assert.ok(invalid, 'v5 namespace should be invalid');
   });
 
   test('v3/v5 constants', () => {


### PR DESCRIPTION
For `v35`, I did a faster parsing of uuid value. This greatly affected the performance.
When parsing a value, it is also validated.

But the bundle size is slightly exceeded…

t’s up to you to decide if this performance increase (and uuid validation) is worth increasing build size.

(Your current solution does not validate uuid strings)

Benchmark master:

```
uuidv1() x 1,644,613 ops/sec ±1.21% (91 runs sampled)
uuidv1() fill existing array x 7,209,045 ops/sec ±0.82% (91 runs sampled)
uuidv4() x 432,989 ops/sec ±0.91% (92 runs sampled)
uuidv4() fill existing array x 454,731 ops/sec ±0.74% (93 runs sampled)
uuidv3() x 137,231 ops/sec ±0.78% (86 runs sampled)
uuidv5() x 135,756 ops/sec ±1.27% (85 runs sampled)
```

Benchmark this branch:

```
uuidv1() x 1,645,002 ops/sec ±1.09% (89 runs sampled)
uuidv1() fill existing array x 7,294,826 ops/sec ±0.82% (92 runs sampled)
uuidv4() x 457,979 ops/sec ±0.76% (90 runs sampled)
uuidv4() fill existing array x 466,131 ops/sec ±0.76% (91 runs sampled)
uuidv3() x 253,029 ops/sec ±1.01% (83 runs sampled)
uuidv5() x 254,426 ops/sec ±1.22% (84 runs sampled)
```