### PR TITLE
fix: export package.json required by react-native and bundlers

### DIFF
--- a/examples/node-commonjs/example.js
+++ b/examples/node-commonjs/example.js
@@ -45,3 +45,7 @@ console.log('uuid.v3() MY_NAMESPACE', uuid.v3('Hello, World!', MY_NAMESPACE));
 console.log('uuid.v5() DNS', uuid.v5('hello.example.com', uuid.v5.DNS));
 console.log('uuid.v5() URL', uuid.v5('http://example.com/hello', uuid.v5.URL));
 console.log('uuid.v5() MY_NAMESPACE', uuid.v5('Hello, World!', MY_NAMESPACE));
+
+// Some tools like react-native need to introspect the package.json file
+const pkg = require('uuid/package.json');
+console.log('pkg.name', pkg.name);

--- a/examples/node-esmodules/example.mjs
+++ b/examples/node-esmodules/example.mjs
@@ -1,5 +1,6 @@
 import { v1 as uuidv1, v4 as uuidv4, v3 as uuidv3, v5 as uuidv5 } from 'uuid';
 import * as uuid from 'uuid';
+import pkg from 'uuid/package.json';
 
 console.log('uuidv1()', uuidv1());
 
@@ -41,3 +42,6 @@ console.log('uuid.v3() MY_NAMESPACE', uuid.v3('Hello, World!', MY_NAMESPACE));
 console.log('uuid.v5() DNS', uuid.v5('hello.example.com', uuid.v5.DNS));
 console.log('uuid.v5() URL', uuid.v5('http://example.com/hello', uuid.v5.URL));
 console.log('uuid.v5() MY_NAMESPACE', uuid.v5('Hello, World!', MY_NAMESPACE));
+
+// Some tools like react-native need to introspect the package.json file
+console.log('pkg.name', pkg.name);

--- a/examples/node-esmodules/package.json
+++ b/examples/node-esmodules/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "test": "node --experimental-modules example.mjs"
+    "test": "node --experimental-modules --experimental-json-modules example.mjs"
   },
   "dependencies": {
     "uuid": "file:../../.local"

--- a/package.json
+++ b/package.json
@@ -19,8 +19,11 @@
   "sideEffects": false,
   "main": "./dist/index.js",
   "exports": {
-    "require": "./dist/index.js",
-    "import": "./wrapper.mjs"
+    "./package.json": "./package.json",
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./wrapper.mjs"
+    }
   },
   "module": "./dist/esm-node/index.js",
   "browser": {

--- a/scripts/testpack.sh
+++ b/scripts/testpack.sh
@@ -18,4 +18,4 @@ npm init -y
 npm install ../uuid/uuid-*.tgz
 
 node commonjs.js
-node esmodules.mjs
+node --experimental-json-modules esmodules.mjs


### PR DESCRIPTION
It appears that react-native and some bundlers rely on being able to
introspect the package.json file of a npm module. After adding the
`exports` field to package.json, only the paths defined in that field
are accessible to Node.js. In order to support introspection of the
package.json file itself it has to be listed as an export as well (see:
https://github.com/ai/nanoevents/issues/44#issuecomment-602010343).

It is currently being discussed to change Node.js' behavior again, see:
https://github.com/nodejs/node/issues/33460

Fixes #444