### PR TITLE
feat: slightly improved v1 perf

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,6 +13,12 @@
   },
   "parser": "babel-eslint",
   "rules": {
-    "no-var": ["error"]
+    "no-var": ["error"],
+    "no-empty": [
+      "error",
+      {
+        "allowEmptyCatch": true
+      }
+    ]
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,12 +13,6 @@
   },
   "parser": "babel-eslint",
   "rules": {
-    "no-var": ["error"],
-    "no-empty": [
-      "error",
-      {
-        "allowEmptyCatch": true
-      }
-    ]
+    "no-var": ["error"]
   }
 }

--- a/examples/benchmark/benchmark.js
+++ b/examples/benchmark/benchmark.js
@@ -23,11 +23,7 @@ suite
   .add('uuidv1() fill existing array', function () {
     try {
       uuidv1(null, array, 0);
-    } catch (err) {
-      if (err.code !== 'UUID_V1_LIMIT_PER_SEC') {
-        throw err;
-      }
-    }
+    } catch (err) {}
   })
   .add('uuidv4()', function () {
     uuidv4();

--- a/examples/benchmark/benchmark.js
+++ b/examples/benchmark/benchmark.js
@@ -21,7 +21,13 @@ suite
     uuidv1();
   })
   .add('uuidv1() fill existing array', function () {
-    uuidv1(null, array, 0);
+    try {
+      uuidv1(null, array, 0);
+    } catch (err) {
+      if (err.code !== 'UUID_V1_LIMIT_PER_SEC') {
+        throw err;
+      }
+    }
   })
   .add('uuidv4()', function () {
     uuidv4();

--- a/examples/benchmark/benchmark.js
+++ b/examples/benchmark/benchmark.js
@@ -23,7 +23,11 @@ suite
   .add('uuidv1() fill existing array', function () {
     try {
       uuidv1(null, array, 0);
-    } catch (err) {}
+    } catch (err) {
+      // The spec (https://tools.ietf.org/html/rfc4122#section-4.2.1.2) defines that only 10M/s v1
+      // UUIDs can be generated on a single node. This library throws an error if we hit that limit
+      // (which can happen on modern hardware and modern Node.js versions).
+    }
   })
   .add('uuidv4()', function () {
     uuidv4();

--- a/src/bytesToUuid.js
+++ b/src/bytesToUuid.js
@@ -2,40 +2,36 @@
  * Convert array of 16 byte values to UUID string format of the form:
  * XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
  */
-const byteToHex = [];
+const bth = [];
 
 for (let i = 0; i < 256; ++i) {
-  byteToHex.push((i + 0x100).toString(16).substr(1));
+  bth.push((i + 0x100).toString(16).substr(1));
 }
 
-function bytesToUuid(buf, offset) {
-  const i = offset || 0;
-
-  const bth = byteToHex;
-
+function bytesToUuid(buf, offset = 0) {
   // Note: Be careful editing this code!  It's been tuned for performance
   // and works in ways you may not expect. See https://github.com/uuidjs/uuid/pull/434
   return (
-    bth[buf[i + 0]] +
-    bth[buf[i + 1]] +
-    bth[buf[i + 2]] +
-    bth[buf[i + 3]] +
+    bth[buf[offset + 0]] +
+    bth[buf[offset + 1]] +
+    bth[buf[offset + 2]] +
+    bth[buf[offset + 3]] +
     '-' +
-    bth[buf[i + 4]] +
-    bth[buf[i + 5]] +
+    bth[buf[offset + 4]] +
+    bth[buf[offset + 5]] +
     '-' +
-    bth[buf[i + 6]] +
-    bth[buf[i + 7]] +
+    bth[buf[offset + 6]] +
+    bth[buf[offset + 7]] +
     '-' +
-    bth[buf[i + 8]] +
-    bth[buf[i + 9]] +
+    bth[buf[offset + 8]] +
+    bth[buf[offset + 9]] +
     '-' +
-    bth[buf[i + 10]] +
-    bth[buf[i + 11]] +
-    bth[buf[i + 12]] +
-    bth[buf[i + 13]] +
-    bth[buf[i + 14]] +
-    bth[buf[i + 15]]
+    bth[buf[offset + 10]] +
+    bth[buf[offset + 11]] +
+    bth[buf[offset + 12]] +
+    bth[buf[offset + 13]] +
+    bth[buf[offset + 14]] +
+    bth[buf[offset + 15]]
   ).toLowerCase();
 }
 

--- a/src/bytesToUuid.js
+++ b/src/bytesToUuid.js
@@ -2,36 +2,36 @@
  * Convert array of 16 byte values to UUID string format of the form:
  * XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
  */
-const bth = [];
+const byteToHex = [];
 
 for (let i = 0; i < 256; ++i) {
-  bth.push((i + 0x100).toString(16).substr(1));
+  byteToHex.push((i + 0x100).toString(16).substr(1));
 }
 
 function bytesToUuid(buf, offset = 0) {
   // Note: Be careful editing this code!  It's been tuned for performance
   // and works in ways you may not expect. See https://github.com/uuidjs/uuid/pull/434
   return (
-    bth[buf[offset + 0]] +
-    bth[buf[offset + 1]] +
-    bth[buf[offset + 2]] +
-    bth[buf[offset + 3]] +
+    byteToHex[buf[offset + 0]] +
+    byteToHex[buf[offset + 1]] +
+    byteToHex[buf[offset + 2]] +
+    byteToHex[buf[offset + 3]] +
     '-' +
-    bth[buf[offset + 4]] +
-    bth[buf[offset + 5]] +
+    byteToHex[buf[offset + 4]] +
+    byteToHex[buf[offset + 5]] +
     '-' +
-    bth[buf[offset + 6]] +
-    bth[buf[offset + 7]] +
+    byteToHex[buf[offset + 6]] +
+    byteToHex[buf[offset + 7]] +
     '-' +
-    bth[buf[offset + 8]] +
-    bth[buf[offset + 9]] +
+    byteToHex[buf[offset + 8]] +
+    byteToHex[buf[offset + 9]] +
     '-' +
-    bth[buf[offset + 10]] +
-    bth[buf[offset + 11]] +
-    bth[buf[offset + 12]] +
-    bth[buf[offset + 13]] +
-    bth[buf[offset + 14]] +
-    bth[buf[offset + 15]]
+    byteToHex[buf[offset + 10]] +
+    byteToHex[buf[offset + 11]] +
+    byteToHex[buf[offset + 12]] +
+    byteToHex[buf[offset + 13]] +
+    byteToHex[buf[offset + 14]] +
+    byteToHex[buf[offset + 15]]
   ).toLowerCase();
 }
 

--- a/src/v1.js
+++ b/src/v1.js
@@ -16,7 +16,7 @@ let _lastNSecs = 0;
 // See https://github.com/uuidjs/uuid for API details
 function v1(options, buf, offset) {
   let i = (buf && offset) || 0;
-  const b = buf || [];
+  const b = buf || new Array(16);
 
   options = options || {};
   let node = options.node || _nodeId;
@@ -27,6 +27,7 @@ function v1(options, buf, offset) {
   // system entropy.  See #189
   if (node == null || clockseq == null) {
     const seedBytes = options.random || (options.rng || rng)();
+
     if (node == null) {
       // Per 4.5, create and 48-bit node id, (47 random bits + multicast bit = 1)
       node = _nodeId = [
@@ -38,6 +39,7 @@ function v1(options, buf, offset) {
         seedBytes[5],
       ];
     }
+
     if (clockseq == null) {
       // Per 4.2.2, randomize (14 bit) clockseq
       clockseq = _clockseq = ((seedBytes[6] << 8) | seedBytes[7]) & 0x3fff;
@@ -70,7 +72,9 @@ function v1(options, buf, offset) {
 
   // Per 4.2.1.2 Throw error if too many uuids are requested
   if (nsecs >= 10000) {
-    throw new Error("uuid.v1(): Can't create more than 10M uuids/sec");
+    const error = new Error("uuid.v1(): Can't create more than 10M uuids/sec");
+    error.code = 'UUID_V1_LIMIT_PER_SEC';
+    throw error;
   }
 
   _lastMSecs = msecs;

--- a/src/v1.js
+++ b/src/v1.js
@@ -72,9 +72,7 @@ function v1(options, buf, offset) {
 
   // Per 4.2.1.2 Throw error if too many uuids are requested
   if (nsecs >= 10000) {
-    const error = new Error("uuid.v1(): Can't create more than 10M uuids/sec");
-    error.code = 'UUID_V1_LIMIT_PER_SEC';
-    throw error;
+    throw new Error("uuid.v1(): Can't create more than 10M uuids/sec");
   }
 
   _lastMSecs = msecs;


### PR DESCRIPTION
Hello!

I managed to increase the `uuidv1` generation performance by replacing `[]` to `new Array(16)`.

I also added an error code when throwing an exception for exceeding `v1` generation limit per second.
I would like to add error codes to all your exceptions. To make it easier to identify the error by its code (instead of a message).
But we need to work on the names of the error codes. We need to standardize names (or somewhere to look).

If at all you like the idea with error codes =)
If not, then I can remove them.

Benchmark master:

```
uuidv1() x 1,634,946 ops/sec ±0.82% (90 runs sampled)
uuidv1() fill existing array x 7,727,514 ops/sec ±0.63% (92 runs sampled)
uuidv4() x 449,289 ops/sec ±0.63% (95 runs sampled)
uuidv4() fill existing array x 463,831 ops/sec ±0.70% (92 runs sampled)
uuidv3() x 144,401 ops/sec ±0.86% (87 runs sampled)
uuidv5() x 147,395 ops/sec ±1.17% (88 runs sampled)
```

Benchmark this branch:

```
uuidv1() x 1,723,775 ops/sec ±1.21% (92 runs sampled)
uuidv1() fill existing array x 7,763,768 ops/sec ±0.98% (91 runs sampled)
uuidv4() x 425,037 ops/sec ±0.49% (93 runs sampled)
uuidv4() fill existing array x 444,126 ops/sec ±0.52% (95 runs sampled)
uuidv3() x 142,065 ops/sec ±0.85% (88 runs sampled)
uuidv5() x 142,814 ops/sec ±1.04% (88 runs sampled)
```