### PR TITLE
feat: remove deprecated v4 string parameter

### DIFF
--- a/src/v4.js
+++ b/src/v4.js
@@ -2,11 +2,6 @@ import rng from './rng.js';
 import bytesToUuid from './bytesToUuid.js';
 
 function v4(options, buf, offset) {
-  if (typeof options === 'string') {
-    buf = options === 'binary' ? new Uint8Array(16) : null;
-    options = null;
-  }
-
   options = options || {};
 
   const rnds = options.random || (options.rng || rng)();


### PR DESCRIPTION
In version 1.x of this library it was possible to call `v4('binary')` in
order to receive a byte array instead of a string representation. This
function signature was deprecated in 2.x (but not removed in 3.x as it
should have been).

The correct way to get a binary representation of a uuid is to pass an
array-like object as a second parameter:

```
const buffer = new Array();
v4(null, buffer);
```

Fixes #437.

<!--
Thank you for your contribution!

If your pull request contains considerable changes please run the benchmark before and after your
changes and include the results in the pull request description. To run the benchmark execute:

    npm run test:benchmark

from the root of this repository.
-->
