### PR TITLE
chore: add proseWrap prettier config to wrap markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,23 +1,34 @@
 # Changelog
 
-All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+All notable changes to this project will be documented in this file. See
+[standard-version](https://github.com/conventional-changelog/standard-version) for commit
+guidelines.
 
 ## [8.1.0](https://github.com/uuidjs/uuid/compare/v8.0.0...v8.1.0) (2020-05-20)
 
 ### Features
 
-- improve v4 performance by reusing random number array ([#435](https://github.com/uuidjs/uuid/issues/435)) ([bf4af0d](https://github.com/uuidjs/uuid/commit/bf4af0d711b4d2ed03d1f74fd12ad0baa87dc79d))
-- optimize V8 performance of bytesToUuid ([#434](https://github.com/uuidjs/uuid/issues/434)) ([e156415](https://github.com/uuidjs/uuid/commit/e156415448ec1af2351fa0b6660cfb22581971f2))
+- improve v4 performance by reusing random number array
+  ([#435](https://github.com/uuidjs/uuid/issues/435))
+  ([bf4af0d](https://github.com/uuidjs/uuid/commit/bf4af0d711b4d2ed03d1f74fd12ad0baa87dc79d))
+- optimize V8 performance of bytesToUuid ([#434](https://github.com/uuidjs/uuid/issues/434))
+  ([e156415](https://github.com/uuidjs/uuid/commit/e156415448ec1af2351fa0b6660cfb22581971f2))
 
 ### Bug Fixes
 
-- export package.json required by react-native and bundlers ([#449](https://github.com/uuidjs/uuid/issues/449)) ([be1c8fe](https://github.com/uuidjs/uuid/commit/be1c8fe9a3206c358e0059b52fafd7213aa48a52)), closes [/github.com/ai/nanoevents/issues/44#issuecomment-602010343](https://github.com/uuidjs//github.com/ai/nanoevents/issues/44/issues/issuecomment-602010343) [#444](https://github.com/uuidjs/uuid/issues/444)
+- export package.json required by react-native and bundlers
+  ([#449](https://github.com/uuidjs/uuid/issues/449))
+  ([be1c8fe](https://github.com/uuidjs/uuid/commit/be1c8fe9a3206c358e0059b52fafd7213aa48a52)),
+  closes
+  [/github.com/ai/nanoevents/issues/44#issuecomment-602010343](https://github.com/uuidjs//github.com/ai/nanoevents/issues/44/issues/issuecomment-602010343)
+  [#444](https://github.com/uuidjs/uuid/issues/444)
 
 ## [8.0.0](https://github.com/uuidjs/uuid/compare/v7.0.3...v8.0.0) (2020-04-29)
 
 ### ⚠ BREAKING CHANGES
 
-- For native ECMAScript Module (ESM) usage in Node.js only named exports are exposed, there is no more default export.
+- For native ECMAScript Module (ESM) usage in Node.js only named exports are exposed, there is no
+  more default export.
 
   ```diff
   -import uuid from 'uuid';
@@ -26,7 +37,8 @@ All notable changes to this project will be documented in this file. See [standa
   +uuidv4(); // ⇨ '9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d'
   ```
 
-- Deep requiring specific algorithms of this library like `require('uuid/v4')`, which has been deprecated in `uuid@7`, is no longer supported.
+- Deep requiring specific algorithms of this library like `require('uuid/v4')`, which has been
+  deprecated in `uuid@7`, is no longer supported.
 
   Instead use the named exports that this module exports.
 
@@ -48,75 +60,105 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### Features
 
-- native Node.js ES Modules (wrapper approach) ([#423](https://github.com/uuidjs/uuid/issues/423)) ([2d9f590](https://github.com/uuidjs/uuid/commit/2d9f590ad9701d692625c07ed62f0a0f91227991)), closes [#245](https://github.com/uuidjs/uuid/issues/245) [#419](https://github.com/uuidjs/uuid/issues/419) [#342](https://github.com/uuidjs/uuid/issues/342)
-- remove deep requires ([#426](https://github.com/uuidjs/uuid/issues/426)) ([daf72b8](https://github.com/uuidjs/uuid/commit/daf72b84ceb20272a81bb5fbddb05dd95922cbba))
+- native Node.js ES Modules (wrapper approach) ([#423](https://github.com/uuidjs/uuid/issues/423))
+  ([2d9f590](https://github.com/uuidjs/uuid/commit/2d9f590ad9701d692625c07ed62f0a0f91227991)),
+  closes [#245](https://github.com/uuidjs/uuid/issues/245)
+  [#419](https://github.com/uuidjs/uuid/issues/419)
+  [#342](https://github.com/uuidjs/uuid/issues/342)
+- remove deep requires ([#426](https://github.com/uuidjs/uuid/issues/426))
+  ([daf72b8](https://github.com/uuidjs/uuid/commit/daf72b84ceb20272a81bb5fbddb05dd95922cbba))
 
 ### Bug Fixes
 
-- add CommonJS syntax example to README quickstart section ([#417](https://github.com/uuidjs/uuid/issues/417)) ([e0ec840](https://github.com/uuidjs/uuid/commit/e0ec8402c7ad44b7ef0453036c612f5db513fda0))
+- add CommonJS syntax example to README quickstart section
+  ([#417](https://github.com/uuidjs/uuid/issues/417))
+  ([e0ec840](https://github.com/uuidjs/uuid/commit/e0ec8402c7ad44b7ef0453036c612f5db513fda0))
 
 ### [7.0.3](https://github.com/uuidjs/uuid/compare/v7.0.2...v7.0.3) (2020-03-31)
 
 ### Bug Fixes
 
-- make deep require deprecation warning work in browsers ([#409](https://github.com/uuidjs/uuid/issues/409)) ([4b71107](https://github.com/uuidjs/uuid/commit/4b71107d8c0d2ef56861ede6403fc9dc35a1e6bf)), closes [#408](https://github.com/uuidjs/uuid/issues/408)
+- make deep require deprecation warning work in browsers
+  ([#409](https://github.com/uuidjs/uuid/issues/409))
+  ([4b71107](https://github.com/uuidjs/uuid/commit/4b71107d8c0d2ef56861ede6403fc9dc35a1e6bf)),
+  closes [#408](https://github.com/uuidjs/uuid/issues/408)
 
 ### [7.0.2](https://github.com/uuidjs/uuid/compare/v7.0.1...v7.0.2) (2020-03-04)
 
 ### Bug Fixes
 
-- make access to msCrypto consistent ([#393](https://github.com/uuidjs/uuid/issues/393)) ([8bf2a20](https://github.com/uuidjs/uuid/commit/8bf2a20f3565df743da7215eebdbada9d2df118c))
-- simplify link in deprecation warning ([#391](https://github.com/uuidjs/uuid/issues/391)) ([bb2c8e4](https://github.com/uuidjs/uuid/commit/bb2c8e4e9f4c5f9c1eaaf3ea59710c633cd90cb7))
-- update links to match content in readme ([#386](https://github.com/uuidjs/uuid/issues/386)) ([44f2f86](https://github.com/uuidjs/uuid/commit/44f2f86e9d2bbf14ee5f0f00f72a3db1292666d4))
+- make access to msCrypto consistent ([#393](https://github.com/uuidjs/uuid/issues/393))
+  ([8bf2a20](https://github.com/uuidjs/uuid/commit/8bf2a20f3565df743da7215eebdbada9d2df118c))
+- simplify link in deprecation warning ([#391](https://github.com/uuidjs/uuid/issues/391))
+  ([bb2c8e4](https://github.com/uuidjs/uuid/commit/bb2c8e4e9f4c5f9c1eaaf3ea59710c633cd90cb7))
+- update links to match content in readme ([#386](https://github.com/uuidjs/uuid/issues/386))
+  ([44f2f86](https://github.com/uuidjs/uuid/commit/44f2f86e9d2bbf14ee5f0f00f72a3db1292666d4))
 
 ### [7.0.1](https://github.com/uuidjs/uuid/compare/v7.0.0...v7.0.1) (2020-02-25)
 
 ### Bug Fixes
 
-- clean up esm builds for node and browser ([#383](https://github.com/uuidjs/uuid/issues/383)) ([59e6a49](https://github.com/uuidjs/uuid/commit/59e6a49e7ce7b3e8fb0f3ee52b9daae72af467dc))
-- provide browser versions independent from module system ([#380](https://github.com/uuidjs/uuid/issues/380)) ([4344a22](https://github.com/uuidjs/uuid/commit/4344a22e7aed33be8627eeaaf05360f256a21753)), closes [#378](https://github.com/uuidjs/uuid/issues/378)
+- clean up esm builds for node and browser ([#383](https://github.com/uuidjs/uuid/issues/383))
+  ([59e6a49](https://github.com/uuidjs/uuid/commit/59e6a49e7ce7b3e8fb0f3ee52b9daae72af467dc))
+- provide browser versions independent from module system
+  ([#380](https://github.com/uuidjs/uuid/issues/380))
+  ([4344a22](https://github.com/uuidjs/uuid/commit/4344a22e7aed33be8627eeaaf05360f256a21753)),
+  closes [#378](https://github.com/uuidjs/uuid/issues/378)
 
 ## [7.0.0](https://github.com/uuidjs/uuid/compare/v3.4.0...v7.0.0) (2020-02-24)
 
 ### ⚠ BREAKING CHANGES
 
-- The default export, which used to be the v4() method
-  but which was already discouraged in v3.x of this library, has been
-  removed.
-- Explicitly note that deep imports of the different uuid
-  version functions are deprecated and no longer encouraged and that
-  ECMAScript module named imports should be used instead.
-  Emit a deprecation warning for people who deep-require the different
-  algorithm variants.
-- Remove builtin support for insecure random number
-  generators in the browser. Users who want that will have to supply their
-  own random number generator function.
-- Remove support for generating v3 and v5 UUIDs in
-  Node.js<4.x
-- Convert code base to ECMAScript Modules (ESM) and
-  release CommonJS build for node and ESM build for browser bundlers.
+- The default export, which used to be the v4() method but which was already discouraged in v3.x of
+  this library, has been removed.
+- Explicitly note that deep imports of the different uuid version functions are deprecated and no
+  longer encouraged and that ECMAScript module named imports should be used instead. Emit a
+  deprecation warning for people who deep-require the different algorithm variants.
+- Remove builtin support for insecure random number generators in the browser. Users who want that
+  will have to supply their own random number generator function.
+- Remove support for generating v3 and v5 UUIDs in Node.js<4.x
+- Convert code base to ECMAScript Modules (ESM) and release CommonJS build for node and ESM build
+  for browser bundlers.
 
 ### Features
 
-- add UMD build to npm package ([#357](https://github.com/uuidjs/uuid/issues/357)) ([4e75adf](https://github.com/uuidjs/uuid/commit/4e75adf435196f28e3fbbe0185d654b5ded7ca2c)), closes [#345](https://github.com/uuidjs/uuid/issues/345)
-- add various es module and CommonJS examples ([b238510](https://github.com/uuidjs/uuid/commit/b238510bf352463521f74bab175a3af9b7a42555))
-- ensure that docs are up-to-date in CI ([ee5e77d](https://github.com/uuidjs/uuid/commit/ee5e77db547474f5a8f23d6c857a6d399209986b))
-- hybrid CommonJS & ECMAScript modules build ([a3f078f](https://github.com/uuidjs/uuid/commit/a3f078faa0baff69ab41aed08e041f8f9c8993d0))
-- remove insecure fallback random number generator ([3a5842b](https://github.com/uuidjs/uuid/commit/3a5842b141a6e5de0ae338f391661e6b84b167c9)), closes [#173](https://github.com/uuidjs/uuid/issues/173)
-- remove support for pre Node.js v4 Buffer API ([#356](https://github.com/uuidjs/uuid/issues/356)) ([b59b5c5](https://github.com/uuidjs/uuid/commit/b59b5c5ecad271c5453f1a156f011671f6d35627))
-- rename repository to github:uuidjs/uuid ([#351](https://github.com/uuidjs/uuid/issues/351)) ([c37a518](https://github.com/uuidjs/uuid/commit/c37a518e367ac4b6d0aa62dba1bc6ce9e85020f7)), closes [#338](https://github.com/uuidjs/uuid/issues/338)
+- add UMD build to npm package ([#357](https://github.com/uuidjs/uuid/issues/357))
+  ([4e75adf](https://github.com/uuidjs/uuid/commit/4e75adf435196f28e3fbbe0185d654b5ded7ca2c)),
+  closes [#345](https://github.com/uuidjs/uuid/issues/345)
+- add various es module and CommonJS examples
+  ([b238510](https://github.com/uuidjs/uuid/commit/b238510bf352463521f74bab175a3af9b7a42555))
+- ensure that docs are up-to-date in CI
+  ([ee5e77d](https://github.com/uuidjs/uuid/commit/ee5e77db547474f5a8f23d6c857a6d399209986b))
+- hybrid CommonJS & ECMAScript modules build
+  ([a3f078f](https://github.com/uuidjs/uuid/commit/a3f078faa0baff69ab41aed08e041f8f9c8993d0))
+- remove insecure fallback random number generator
+  ([3a5842b](https://github.com/uuidjs/uuid/commit/3a5842b141a6e5de0ae338f391661e6b84b167c9)),
+  closes [#173](https://github.com/uuidjs/uuid/issues/173)
+- remove support for pre Node.js v4 Buffer API ([#356](https://github.com/uuidjs/uuid/issues/356))
+  ([b59b5c5](https://github.com/uuidjs/uuid/commit/b59b5c5ecad271c5453f1a156f011671f6d35627))
+- rename repository to github:uuidjs/uuid ([#351](https://github.com/uuidjs/uuid/issues/351))
+  ([c37a518](https://github.com/uuidjs/uuid/commit/c37a518e367ac4b6d0aa62dba1bc6ce9e85020f7)),
+  closes [#338](https://github.com/uuidjs/uuid/issues/338)
 
 ### Bug Fixes
 
-- add deep-require proxies for local testing and adjust tests ([#365](https://github.com/uuidjs/uuid/issues/365)) ([7fedc79](https://github.com/uuidjs/uuid/commit/7fedc79ac8fda4bfd1c566c7f05ef4ac13b2db48))
-- add note about removal of default export ([#372](https://github.com/uuidjs/uuid/issues/372)) ([12749b7](https://github.com/uuidjs/uuid/commit/12749b700eb49db8a9759fd306d8be05dbfbd58c)), closes [#370](https://github.com/uuidjs/uuid/issues/370)
-- deprecated deep requiring of the different algorithm versions ([#361](https://github.com/uuidjs/uuid/issues/361)) ([c0bdf15](https://github.com/uuidjs/uuid/commit/c0bdf15e417639b1aeb0b247b2fb11f7a0a26b23))
+- add deep-require proxies for local testing and adjust tests
+  ([#365](https://github.com/uuidjs/uuid/issues/365))
+  ([7fedc79](https://github.com/uuidjs/uuid/commit/7fedc79ac8fda4bfd1c566c7f05ef4ac13b2db48))
+- add note about removal of default export ([#372](https://github.com/uuidjs/uuid/issues/372))
+  ([12749b7](https://github.com/uuidjs/uuid/commit/12749b700eb49db8a9759fd306d8be05dbfbd58c)),
+  closes [#370](https://github.com/uuidjs/uuid/issues/370)
+- deprecated deep requiring of the different algorithm versions
+  ([#361](https://github.com/uuidjs/uuid/issues/361))
+  ([c0bdf15](https://github.com/uuidjs/uuid/commit/c0bdf15e417639b1aeb0b247b2fb11f7a0a26b23))
 
 ## [3.4.0](https://github.com/uuidjs/uuid/compare/v3.3.3...v3.4.0) (2020-01-16)
 
 ### Features
 
-- rename repository to github:uuidjs/uuid ([#351](https://github.com/uuidjs/uuid/issues/351)) ([e2d7314](https://github.com/uuidjs/uuid/commit/e2d7314)), closes [#338](https://github.com/uuidjs/uuid/issues/338)
+- rename repository to github:uuidjs/uuid ([#351](https://github.com/uuidjs/uuid/issues/351))
+  ([e2d7314](https://github.com/uuidjs/uuid/commit/e2d7314)), closes
+  [#338](https://github.com/uuidjs/uuid/issues/338)
 
 ## [3.3.3](https://github.com/uuidjs/uuid/compare/v3.3.2...v3.3.3) (2019-08-19)
 
@@ -135,37 +177,51 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### Bug Fixes
 
-- fix [#284](https://github.com/uuidjs/uuid/issues/284) by setting function name in try-catch ([f2a60f2](https://github.com/uuidjs/uuid/commit/f2a60f2))
+- fix [#284](https://github.com/uuidjs/uuid/issues/284) by setting function name in try-catch
+  ([f2a60f2](https://github.com/uuidjs/uuid/commit/f2a60f2))
 
 # [3.3.0](https://github.com/uuidjs/uuid/compare/v3.2.1...v3.3.0) (2018-06-22)
 
 ### Bug Fixes
 
-- assignment to readonly property to allow running in strict mode ([#270](https://github.com/uuidjs/uuid/issues/270)) ([d062fdc](https://github.com/uuidjs/uuid/commit/d062fdc))
-- fix [#229](https://github.com/uuidjs/uuid/issues/229) ([c9684d4](https://github.com/uuidjs/uuid/commit/c9684d4))
-- Get correct version of IE11 crypto ([#274](https://github.com/uuidjs/uuid/issues/274)) ([153d331](https://github.com/uuidjs/uuid/commit/153d331))
-- mem issue when generating uuid ([#267](https://github.com/uuidjs/uuid/issues/267)) ([c47702c](https://github.com/uuidjs/uuid/commit/c47702c))
+- assignment to readonly property to allow running in strict mode
+  ([#270](https://github.com/uuidjs/uuid/issues/270))
+  ([d062fdc](https://github.com/uuidjs/uuid/commit/d062fdc))
+- fix [#229](https://github.com/uuidjs/uuid/issues/229)
+  ([c9684d4](https://github.com/uuidjs/uuid/commit/c9684d4))
+- Get correct version of IE11 crypto ([#274](https://github.com/uuidjs/uuid/issues/274))
+  ([153d331](https://github.com/uuidjs/uuid/commit/153d331))
+- mem issue when generating uuid ([#267](https://github.com/uuidjs/uuid/issues/267))
+  ([c47702c](https://github.com/uuidjs/uuid/commit/c47702c))
 
 ### Features
 
-- enforce Conventional Commit style commit messages ([#282](https://github.com/uuidjs/uuid/issues/282)) ([cc9a182](https://github.com/uuidjs/uuid/commit/cc9a182))
+- enforce Conventional Commit style commit messages
+  ([#282](https://github.com/uuidjs/uuid/issues/282))
+  ([cc9a182](https://github.com/uuidjs/uuid/commit/cc9a182))
 
 ## [3.2.1](https://github.com/uuidjs/uuid/compare/v3.2.0...v3.2.1) (2018-01-16)
 
 ### Bug Fixes
 
-- use msCrypto if available. Fixes [#241](https://github.com/uuidjs/uuid/issues/241) ([#247](https://github.com/uuidjs/uuid/issues/247)) ([1fef18b](https://github.com/uuidjs/uuid/commit/1fef18b))
+- use msCrypto if available. Fixes [#241](https://github.com/uuidjs/uuid/issues/241)
+  ([#247](https://github.com/uuidjs/uuid/issues/247))
+  ([1fef18b](https://github.com/uuidjs/uuid/commit/1fef18b))
 
 # [3.2.0](https://github.com/uuidjs/uuid/compare/v3.1.0...v3.2.0) (2018-01-16)
 
 ### Bug Fixes
 
-- remove mistakenly added typescript dependency, rollback version (standard-version will auto-increment) ([09fa824](https://github.com/uuidjs/uuid/commit/09fa824))
-- use msCrypto if available. Fixes [#241](https://github.com/uuidjs/uuid/issues/241) ([#247](https://github.com/uuidjs/uuid/issues/247)) ([1fef18b](https://github.com/uuidjs/uuid/commit/1fef18b))
+- remove mistakenly added typescript dependency, rollback version (standard-version will
+  auto-increment) ([09fa824](https://github.com/uuidjs/uuid/commit/09fa824))
+- use msCrypto if available. Fixes [#241](https://github.com/uuidjs/uuid/issues/241)
+  ([#247](https://github.com/uuidjs/uuid/issues/247))
+  ([1fef18b](https://github.com/uuidjs/uuid/commit/1fef18b))
 
 ### Features
 
-- Add v3 Support ([#217](https://github.com/uuidjs/uuid/issues/217)) ([d94f726](https://github.com/uuidjs/uuid/commit/d94f726))
+- Add v3 Support ([#217](https://github.com/uuidjs/uuid/issues/217))
+  ([d94f726](https://github.com/uuidjs/uuid/commit/d94f726))
 
 # [3.1.0](https://github.com/uuidjs/uuid/compare/v3.1.0...v3.0.1) (2017-06-17)
 
@@ -206,4 +262,5 @@ All notable changes to this project will be documented in this file. See [standa
 
 - Support for version 1 ids, thanks to [@ctavan](https://github.com/ctavan)!
 - Support for node.js crypto API
-- De-emphasizing performance in favor of a) cryptographic quality PRNGs where available and b) more manageable code
+- De-emphasizing performance in favor of a) cryptographic quality PRNGs where available and b) more
+  manageable code

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -2,20 +2,17 @@ The MIT License (MIT)
 
 Copyright (c) 2010-2020 Robert Kieffer and other contributors
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ For the creation of [RFC4122](http://www.ietf.org/rfc/rfc4122.txt) UUIDs
 - **Small** - Zero-dependency, small footprint, plays nice with "tree shaking" packagers
 - **CLI** - Includes the [`uuid` command line](#command-line) utility
 
-**Upgrading from uuid\@3?** Your code is probably okay, but check out [Upgrading
-From uuid\@3](#upgrading-from-uuid3) for details.
+**Upgrading from uuid\@3?** Your code is probably okay, but check out
+[Upgrading From uuid\@3](#upgrading-from-uuid3) for details.
 
 ## Quickstart
 
@@ -26,15 +26,16 @@ From uuid\@3](#upgrading-from-uuid3) for details.
 npm install uuid
 ```
 
-Once installed, decide which type of UUID you need. RFC4122 provides for four
-versions, all of which are supported here. In order of popularity, they are:
+Once installed, decide which type of UUID you need. RFC4122 provides for four versions, all of which
+are supported here. In order of popularity, they are:
 
 - Version 4 (random) - Created from cryptographically-strong random values
 - Version 1 (timestamp) - Created from the system clock (plus random values)
 - Version 5 (namespace, SHA-1) - Created from user-supplied name and namespace strings
 - Version 3 (namespace, MD5) - Like version 5, above, but with a poorer hash algorithm
 
-**Unsure which one to use?** Use version 4 (random) unless you have a specific need for one of the other versions. See also [this FAQ](https://github.com/tc39/proposal-uuid#faq).
+**Unsure which one to use?** Use version 4 (random) unless you have a specific need for one of the
+other versions. See also [this FAQ](https://github.com/tc39/proposal-uuid#faq).
 
 ### Create Version 4 (Random) UUIDs
 
@@ -61,12 +62,12 @@ uuidv1(); // ⇨ '2c5ea4c0-4067-11e9-8bad-9b1deb4d3b7d'
 
 ### Create Version 3 or Version 5 (Namespace) UUIDs
 
-&#x26a0;&#xfe0f; Version 3 and Version 5 UUIDs are basically the same, differing
-only in the underlying hash algorithm. Note that per the RFC, "_If backward
-compatibility is not an issue, SHA-1 [Version 5] is preferred_."
+&#x26a0;&#xfe0f; Version 3 and Version 5 UUIDs are basically the same, differing only in the
+underlying hash algorithm. Note that per the RFC, "_If backward compatibility is not an issue, SHA-1
+[Version 5] is preferred_."
 
-&#x26a0;&#xfe0f; If using a custom namespace **be sure to generate your own
-namespace UUID**. You can grab one [here](https://www.uuidgenerator.net/).
+&#x26a0;&#xfe0f; If using a custom namespace **be sure to generate your own namespace UUID**. You
+can grab one [here](https://www.uuidgenerator.net/).
 
 ```javascript
 import { v5 as uuidv5 } from 'uuid'; // For version 5
@@ -103,8 +104,10 @@ uuidv4(options, buffer, offset);
 Generate and return a RFC4122 version 4 UUID.
 
 - `options` - (Object) Optional uuid state to apply. Properties may include:
-  - `random` - (Number[16]) Array of 16 numbers (0-255) to use in place of randomly generated values. Takes precedence over `options.rng`.
-  - `rng` - (Function) Random # generator function that returns an Array[16] of byte values (0-255). Alternative to `options.random`.
+  - `random` - (Number[16]) Array of 16 numbers (0-255) to use in place of randomly generated
+    values. Takes precedence over `options.rng`.
+  - `rng` - (Function) Random # generator function that returns an Array[16] of byte values (0-255).
+    Alternative to `options.random`.
 - `buffer` - (Array | Buffer) Array or buffer where UUID bytes are to be written.
 - `offset` - (Number) Starting index in `buffer` at which to begin writing.
 
@@ -170,18 +173,25 @@ uuidv1(options, buffer, offset);
 Generate and return a RFC4122 version 1 (timestamp) UUID.
 
 - `options` - (Object) Optional uuid state to apply. Properties may include:
-  - `node` - (Array) Node id as Array of 6 bytes (per 4.1.6). Default: Randomly generated ID. See note 1.
-  - `clockseq` - (Number between 0 - 0x3fff) RFC clock sequence. Default: An internally maintained clockseq is used.
+  - `node` - (Array) Node id as Array of 6 bytes (per 4.1.6). Default: Randomly generated ID. See
+    note 1.
+  - `clockseq` - (Number between 0 - 0x3fff) RFC clock sequence. Default: An internally maintained
+    clockseq is used.
   - `msecs` - (Number) Time in milliseconds since unix Epoch. Default: The current time is used.
-  - `nsecs` - (Number between 0-9999) additional time, in 100-nanosecond units. Ignored if `msecs` is unspecified. Default: internal uuid counter is used, as per 4.2.1.2.
-  - `random` - (Number[16]) Array of 16 numbers (0-255) to use for initialization of `node` and `clockseq` as described above. Takes precedence over `options.rng`.
-  - `rng` - (Function) Random # generator function that returns an Array[16] of byte values (0-255). Alternative to `options.random`.
+  - `nsecs` - (Number between 0-9999) additional time, in 100-nanosecond units. Ignored if `msecs`
+    is unspecified. Default: internal uuid counter is used, as per 4.2.1.2.
+  - `random` - (Number[16]) Array of 16 numbers (0-255) to use for initialization of `node` and
+    `clockseq` as described above. Takes precedence over `options.rng`.
+  - `rng` - (Function) Random # generator function that returns an Array[16] of byte values (0-255).
+    Alternative to `options.random`.
 - `buffer` - (Array | Buffer) Array or buffer where UUID bytes are to be written.
 - `offset` - (Number) Starting index in `buffer` at which to begin writing.
 
 Returns `buffer`, if specified, otherwise the string form of the UUID
 
-Note: The default [node id](https://tools.ietf.org/html/rfc4122#section-4.1.6) (the last 12 digits in the UUID) is generated once, randomly, on process startup, and then remains unchanged for the duration of the process.
+Note: The default [node id](https://tools.ietf.org/html/rfc4122#section-4.1.6) (the last 12 digits
+in the UUID) is generated once, randomly, on process startup, and then remains unchanged for the
+duration of the process.
 
 Example: Generate string UUID with fully-specified options
 
@@ -243,7 +253,8 @@ uuidv5('hello world', MY_NAMESPACE); // ⇨ '9f282611-e0fd-5650-8953-89c8e342da0
 
 ### Version 3 (Namespace)
 
-&#x26a0;&#xfe0f; Note: Per the RFC, "_If backward compatibility is not an issue, SHA-1 [Version 5] is preferred_."
+&#x26a0;&#xfe0f; Note: Per the RFC, "_If backward compatibility is not an issue, SHA-1 [Version 5]
+is preferred_."
 
 ```javascript
 import { v3 as uuidv3 } from 'uuid';
@@ -278,7 +289,8 @@ $ uuid
 ddeb27fb-d9a0-4624-be4d-4615062daed4
 ```
 
-The default is to generate version 4 UUIDS, however the other versions are supported. Type `uuid --help` for details:
+The default is to generate version 4 UUIDS, however the other versions are supported. Type
+`uuid --help` for details:
 
 ```
 $ uuid --help
@@ -297,12 +309,12 @@ defined by RFC4122
 
 ## ECMAScript Modules
 
-This library comes with [ECMAScript
-Modules](https://www.ecma-international.org/ecma-262/6.0/#sec-modules) (ESM) support for Node.js
-versions that support it ([example](./examples/node-esmodules/)) as well as bundlers like
-[rollup.js](https://rollupjs.org/guide/en/#tree-shaking) ([example](./examples/browser-rollup/))
-and [webpack](https://webpack.js.org/guides/tree-shaking/)
-([example](./examples/browser-webpack/)) (targeting both, Node.js and browser environments).
+This library comes with
+[ECMAScript Modules](https://www.ecma-international.org/ecma-262/6.0/#sec-modules) (ESM) support for
+Node.js versions that support it ([example](./examples/node-esmodules/)) as well as bundlers like
+[rollup.js](https://rollupjs.org/guide/en/#tree-shaking) ([example](./examples/browser-rollup/)) and
+[webpack](https://webpack.js.org/guides/tree-shaking/) ([example](./examples/browser-webpack/))
+(targeting both, Node.js and browser environments).
 
 ```javascript
 import { v4 as uuidv4 } from 'uuid';
@@ -357,7 +369,8 @@ API is not supported. This issue can be resolved by adding an appropriate polyfi
 
 ### React Native
 
-1. Install [`react-native-get-random-values`](https://github.com/LinusU/react-native-get-random-values#readme)
+1. Install
+   [`react-native-get-random-values`](https://github.com/LinusU/react-native-get-random-values#readme)
 1. Import it before `uuid`:
 
 ```javascript
@@ -367,9 +380,8 @@ import { v4 as uuidv4 } from 'uuid';
 
 ### Web Workers / Service Workers (Edge <= 18)
 
-[In Edge <= 18, Web Crypto is not supported in Web Workers or Service
-Workers](https://caniuse.com/#feat=cryptography) and we are not aware of a polyfill (let us know if
-you find one, please).
+[In Edge <= 18, Web Crypto is not supported in Web Workers or Service Workers](https://caniuse.com/#feat=cryptography)
+and we are not aware of a polyfill (let us know if you find one, please).
 
 ## Upgrading From uuid\@7
 
@@ -395,31 +407,28 @@ uuidv4();
 
 ### Deep Requires No Longer Supported
 
-Deep requires like `require('uuid/v4')` [which have been deprecated in
-uuid\@7](#deep-requires-now-deprecated) are no longer supported.
+Deep requires like `require('uuid/v4')`
+[which have been deprecated in uuid\@7](#deep-requires-now-deprecated) are no longer supported.
 
 ## Upgrading From uuid\@3
 
 "_Wait... what happened to uuid\@4 - uuid\@6?!?_"
 
-In order to avoid confusion with RFC [version 4](#version-4-random) and [version
-5](#version-5-namespace) UUIDs, and a possible [version
-6](http://gh.peabody.io/uuidv6/), releases 4 thru 6 of this module have been
-skipped. Hence, how we're now at uuid\@7.
+In order to avoid confusion with RFC [version 4](#version-4-random) and
+[version 5](#version-5-namespace) UUIDs, and a possible [version 6](http://gh.peabody.io/uuidv6/),
+releases 4 thru 6 of this module have been skipped. Hence, how we're now at uuid\@7.
 
 ### Deep Requires Now Deprecated
 
-uuid\@3 encouraged the use of deep requires to minimize the bundle size of
-browser builds:
+uuid\@3 encouraged the use of deep requires to minimize the bundle size of browser builds:
 
 ```javascript
 const uuidv4 = require('uuid/v4'); // <== NOW DEPRECATED!
 uuidv4();
 ```
 
-As of uuid\@7 this library now provides ECMAScript modules builds, which allow
-packagers like Webpack and Rollup to do "tree-shaking" to remove dead code.
-Instead, use the `import` syntax:
+As of uuid\@7 this library now provides ECMAScript modules builds, which allow packagers like
+Webpack and Rollup to do "tree-shaking" to remove dead code. Instead, use the `import` syntax:
 
 ```javascript
 import { v4 as uuidv4 } from 'uuid';

--- a/README_js.md
+++ b/README_js.md
@@ -29,8 +29,8 @@ For the creation of [RFC4122](http://www.ietf.org/rfc/rfc4122.txt) UUIDs
 - **Small** - Zero-dependency, small footprint, plays nice with "tree shaking" packagers
 - **CLI** - Includes the [`uuid` command line](#command-line) utility
 
-**Upgrading from uuid\@3?** Your code is probably okay, but check out [Upgrading
-From uuid\@3](#upgrading-from-uuid3) for details.
+**Upgrading from uuid\@3?** Your code is probably okay, but check out
+[Upgrading From uuid\@3](#upgrading-from-uuid3) for details.
 
 ## Quickstart
 
@@ -38,15 +38,16 @@ From uuid\@3](#upgrading-from-uuid3) for details.
 npm install uuid
 ```
 
-Once installed, decide which type of UUID you need. RFC4122 provides for four
-versions, all of which are supported here. In order of popularity, they are:
+Once installed, decide which type of UUID you need. RFC4122 provides for four versions, all of which
+are supported here. In order of popularity, they are:
 
 - Version 4 (random) - Created from cryptographically-strong random values
 - Version 1 (timestamp) - Created from the system clock (plus random values)
 - Version 5 (namespace, SHA-1) - Created from user-supplied name and namespace strings
 - Version 3 (namespace, MD5) - Like version 5, above, but with a poorer hash algorithm
 
-**Unsure which one to use?** Use version 4 (random) unless you have a specific need for one of the other versions. See also [this FAQ](https://github.com/tc39/proposal-uuid#faq).
+**Unsure which one to use?** Use version 4 (random) unless you have a specific need for one of the
+other versions. See also [this FAQ](https://github.com/tc39/proposal-uuid#faq).
 
 ### Create Version 4 (Random) UUIDs
 
@@ -73,12 +74,12 @@ uuidv1(); // RESULT
 
 ### Create Version 3 or Version 5 (Namespace) UUIDs
 
-&#x26a0;&#xfe0f; Version 3 and Version 5 UUIDs are basically the same, differing
-only in the underlying hash algorithm. Note that per the RFC, "_If backward
-compatibility is not an issue, SHA-1 [Version 5] is preferred_."
+&#x26a0;&#xfe0f; Version 3 and Version 5 UUIDs are basically the same, differing only in the
+underlying hash algorithm. Note that per the RFC, "_If backward compatibility is not an issue, SHA-1
+[Version 5] is preferred_."
 
-&#x26a0;&#xfe0f; If using a custom namespace **be sure to generate your own
-namespace UUID**. You can grab one [here](https://www.uuidgenerator.net/).
+&#x26a0;&#xfe0f; If using a custom namespace **be sure to generate your own namespace UUID**. You
+can grab one [here](https://www.uuidgenerator.net/).
 
 ```javascript --run v35
 import { v5 as uuidv5 } from 'uuid'; // For version 5
@@ -115,8 +116,10 @@ uuidv4(options, buffer, offset);
 Generate and return a RFC4122 version 4 UUID.
 
 - `options` - (Object) Optional uuid state to apply. Properties may include:
-  - `random` - (Number[16]) Array of 16 numbers (0-255) to use in place of randomly generated values. Takes precedence over `options.rng`.
-  - `rng` - (Function) Random # generator function that returns an Array[16] of byte values (0-255). Alternative to `options.random`.
+  - `random` - (Number[16]) Array of 16 numbers (0-255) to use in place of randomly generated
+    values. Takes precedence over `options.rng`.
+  - `rng` - (Function) Random # generator function that returns an Array[16] of byte values (0-255).
+    Alternative to `options.random`.
 - `buffer` - (Array | Buffer) Array or buffer where UUID bytes are to be written.
 - `offset` - (Number) Starting index in `buffer` at which to begin writing.
 
@@ -170,18 +173,25 @@ uuidv1(options, buffer, offset);
 Generate and return a RFC4122 version 1 (timestamp) UUID.
 
 - `options` - (Object) Optional uuid state to apply. Properties may include:
-  - `node` - (Array) Node id as Array of 6 bytes (per 4.1.6). Default: Randomly generated ID. See note 1.
-  - `clockseq` - (Number between 0 - 0x3fff) RFC clock sequence. Default: An internally maintained clockseq is used.
+  - `node` - (Array) Node id as Array of 6 bytes (per 4.1.6). Default: Randomly generated ID. See
+    note 1.
+  - `clockseq` - (Number between 0 - 0x3fff) RFC clock sequence. Default: An internally maintained
+    clockseq is used.
   - `msecs` - (Number) Time in milliseconds since unix Epoch. Default: The current time is used.
-  - `nsecs` - (Number between 0-9999) additional time, in 100-nanosecond units. Ignored if `msecs` is unspecified. Default: internal uuid counter is used, as per 4.2.1.2.
-  - `random` - (Number[16]) Array of 16 numbers (0-255) to use for initialization of `node` and `clockseq` as described above. Takes precedence over `options.rng`.
-  - `rng` - (Function) Random # generator function that returns an Array[16] of byte values (0-255). Alternative to `options.random`.
+  - `nsecs` - (Number between 0-9999) additional time, in 100-nanosecond units. Ignored if `msecs`
+    is unspecified. Default: internal uuid counter is used, as per 4.2.1.2.
+  - `random` - (Number[16]) Array of 16 numbers (0-255) to use for initialization of `node` and
+    `clockseq` as described above. Takes precedence over `options.rng`.
+  - `rng` - (Function) Random # generator function that returns an Array[16] of byte values (0-255).
+    Alternative to `options.random`.
 - `buffer` - (Array | Buffer) Array or buffer where UUID bytes are to be written.
 - `offset` - (Number) Starting index in `buffer` at which to begin writing.
 
 Returns `buffer`, if specified, otherwise the string form of the UUID
 
-Note: The default [node id](https://tools.ietf.org/html/rfc4122#section-4.1.6) (the last 12 digits in the UUID) is generated once, randomly, on process startup, and then remains unchanged for the duration of the process.
+Note: The default [node id](https://tools.ietf.org/html/rfc4122#section-4.1.6) (the last 12 digits
+in the UUID) is generated once, randomly, on process startup, and then remains unchanged for the
+duration of the process.
 
 Example: Generate string UUID with fully-specified options
 
@@ -232,7 +242,8 @@ uuidv5('hello world', MY_NAMESPACE); // RESULT
 
 ### Version 3 (Namespace)
 
-&#x26a0;&#xfe0f; Note: Per the RFC, "_If backward compatibility is not an issue, SHA-1 [Version 5] is preferred_."
+&#x26a0;&#xfe0f; Note: Per the RFC, "_If backward compatibility is not an issue, SHA-1 [Version 5]
+is preferred_."
 
 ```javascript
 import { v3 as uuidv3 } from 'uuid';
@@ -267,7 +278,8 @@ $ uuid
 ddeb27fb-d9a0-4624-be4d-4615062daed4
 ```
 
-The default is to generate version 4 UUIDS, however the other versions are supported. Type `uuid --help` for details:
+The default is to generate version 4 UUIDS, however the other versions are supported. Type
+`uuid --help` for details:
 
 ```
 $ uuid --help
@@ -286,12 +298,12 @@ defined by RFC4122
 
 ## ECMAScript Modules
 
-This library comes with [ECMAScript
-Modules](https://www.ecma-international.org/ecma-262/6.0/#sec-modules) (ESM) support for Node.js
-versions that support it ([example](./examples/node-esmodules/)) as well as bundlers like
-[rollup.js](https://rollupjs.org/guide/en/#tree-shaking) ([example](./examples/browser-rollup/))
-and [webpack](https://webpack.js.org/guides/tree-shaking/)
-([example](./examples/browser-webpack/)) (targeting both, Node.js and browser environments).
+This library comes with
+[ECMAScript Modules](https://www.ecma-international.org/ecma-262/6.0/#sec-modules) (ESM) support for
+Node.js versions that support it ([example](./examples/node-esmodules/)) as well as bundlers like
+[rollup.js](https://rollupjs.org/guide/en/#tree-shaking) ([example](./examples/browser-rollup/)) and
+[webpack](https://webpack.js.org/guides/tree-shaking/) ([example](./examples/browser-webpack/))
+(targeting both, Node.js and browser environments).
 
 ```javascript
 import { v4 as uuidv4 } from 'uuid';
@@ -346,7 +358,8 @@ API is not supported. This issue can be resolved by adding an appropriate polyfi
 
 ### React Native
 
-1. Install [`react-native-get-random-values`](https://github.com/LinusU/react-native-get-random-values#readme)
+1. Install
+   [`react-native-get-random-values`](https://github.com/LinusU/react-native-get-random-values#readme)
 1. Import it before `uuid`:
 
 ```javascript
@@ -356,9 +369,8 @@ import { v4 as uuidv4 } from 'uuid';
 
 ### Web Workers / Service Workers (Edge <= 18)
 
-[In Edge <= 18, Web Crypto is not supported in Web Workers or Service
-Workers](https://caniuse.com/#feat=cryptography) and we are not aware of a polyfill (let us know if
-you find one, please).
+[In Edge <= 18, Web Crypto is not supported in Web Workers or Service Workers](https://caniuse.com/#feat=cryptography)
+and we are not aware of a polyfill (let us know if you find one, please).
 
 ## Upgrading From uuid\@7
 
@@ -384,31 +396,28 @@ uuidv4();
 
 ### Deep Requires No Longer Supported
 
-Deep requires like `require('uuid/v4')` [which have been deprecated in
-uuid\@7](#deep-requires-now-deprecated) are no longer supported.
+Deep requires like `require('uuid/v4')`
+[which have been deprecated in uuid\@7](#deep-requires-now-deprecated) are no longer supported.
 
 ## Upgrading From uuid\@3
 
 "_Wait... what happened to uuid\@4 - uuid\@6?!?_"
 
-In order to avoid confusion with RFC [version 4](#version-4-random) and [version
-5](#version-5-namespace) UUIDs, and a possible [version
-6](http://gh.peabody.io/uuidv6/), releases 4 thru 6 of this module have been
-skipped. Hence, how we're now at uuid\@7.
+In order to avoid confusion with RFC [version 4](#version-4-random) and
+[version 5](#version-5-namespace) UUIDs, and a possible [version 6](http://gh.peabody.io/uuidv6/),
+releases 4 thru 6 of this module have been skipped. Hence, how we're now at uuid\@7.
 
 ### Deep Requires Now Deprecated
 
-uuid\@3 encouraged the use of deep requires to minimize the bundle size of
-browser builds:
+uuid\@3 encouraged the use of deep requires to minimize the bundle size of browser builds:
 
 ```javascript
 const uuidv4 = require('uuid/v4'); // <== NOW DEPRECATED!
 uuidv4();
 ```
 
-As of uuid\@7 this library now provides ECMAScript modules builds, which allow
-packagers like Webpack and Rollup to do "tree-shaking" to remove dead code.
-Instead, use the `import` syntax:
+As of uuid\@7 this library now provides ECMAScript modules builds, which allow packagers like
+Webpack and Rollup to do "tree-shaking" to remove dead code. Instead, use the `import` syntax:
 
 ```javascript
 import { v4 as uuidv4 } from 'uuid';

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   arrowParens: 'always',
   printWidth: 100,
+  proseWrap: 'always',
   singleQuote: true,
   trailingComma: 'all',
 };


### PR DESCRIPTION
I no longer want to try to achieve consistent line lengths in markdown
so I'd prefer prettier to do that for me.

<!--
Thank you for your contribution!

If your pull request contains considerable changes please run the benchmark before and after your
changes and include the results in the pull request description. To run the benchmark execute:

    npm run test:benchmark

from the root of this repository.
-->
