### PR TITLE
Add an exports "browser" entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,11 +19,12 @@
   "sideEffects": false,
   "main": "./dist/index.js",
   "exports": {
-    "./package.json": "./package.json",
     ".": {
+      "browser": "./dist/esm-browser/index.js",
       "require": "./dist/index.js",
       "import": "./wrapper.mjs"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "module": "./dist/esm-node/index.js",
   "browser": {


### PR DESCRIPTION
It is great to see this package supporting the "exports" field so well.

This adds support for a "browser" entry as well in exports which is a tooling pattern that would be good to encourage as a way to support both the browser field and the exports field together in tools.

Questions / feedback welcome.
