### PR TITLE
fix: concise uuidToBytes

### DIFF
--- a/bundlewatch.config.json
+++ b/bundlewatch.config.json
@@ -1,13 +1,13 @@
 {
   "files": [
     { "path": "./examples/browser-rollup/dist/v1-size.js", "maxSize": "0.8 kB" },
-    { "path": "./examples/browser-rollup/dist/v3-size.js", "maxSize": "1.8 kB" },
+    { "path": "./examples/browser-rollup/dist/v3-size.js", "maxSize": "1.9 kB" },
     { "path": "./examples/browser-rollup/dist/v4-size.js", "maxSize": "0.5 kB" },
     { "path": "./examples/browser-rollup/dist/v5-size.js", "maxSize": "1.2 kB" },
 
     { "path": "./examples/browser-webpack/dist/v1-size.js", "maxSize": "1.3 kB" },
-    { "path": "./examples/browser-webpack/dist/v3-size.js", "maxSize": "2.2 kB" },
+    { "path": "./examples/browser-webpack/dist/v3-size.js", "maxSize": "2.3 kB" },
     { "path": "./examples/browser-webpack/dist/v4-size.js", "maxSize": "0.9 kB" },
-    { "path": "./examples/browser-webpack/dist/v5-size.js", "maxSize": "1.6 kB" }
+    { "path": "./examples/browser-webpack/dist/v5-size.js", "maxSize": "1.7 kB" }
   ]
 }

--- a/src/v35.js
+++ b/src/v35.js
@@ -1,29 +1,12 @@
 import bytesToUuid from './bytesToUuid.js';
 import validate from './validate.js';
 
-// Int32 to 4 bytes https://stackoverflow.com/a/12965194/3684944
-function numberToBytes(num, bytes, offset) {
-  for (let i = 0; i < 4; ++i) {
-    const byte = num & 0xff;
-    // Fill the 4 bytes right-to-left.
-    bytes[offset + 3 - i] = byte;
-    num = (num - byte) / 256;
-  }
-}
-
 function uuidToBytes(uuid) {
   if (!validate(uuid)) {
     return [];
   }
 
-  const bytes = new Array(16);
-
-  numberToBytes(parseInt(uuid.slice(0, 8), 16), bytes, 0);
-  numberToBytes(parseInt(uuid.slice(9, 13) + uuid.slice(14, 18), 16), bytes, 4);
-  numberToBytes(parseInt(uuid.slice(19, 23) + uuid.slice(24, 28), 16), bytes, 8);
-  numberToBytes(parseInt(uuid.slice(28), 16), bytes, 12);
-
-  return bytes;
+  return uuid.match(/[0-9a-f]{2}/gi).map((v) => parseInt(v, 16));
 }
 
 function stringToBytes(str) {


### PR DESCRIPTION
Putting up two possible implementations of `uuidToBytes` for us to consider:

* This PR, `uuidToBytes_concise`, is similar to what's on `master`.  Slightly better perf and compactness, pretty readable.
* PR #464, `uuidToBytes_fast` is @awwit's approach in `v9`, but with the `numberToBytes` stuff done inline.  Yields slightly better performance and saves a few bytes when minified.  Not great readability (as tends to be the case with highly optimized code), hence the extra comments. 

Here are the numbers for the various flavors:

| branch | performance (ops/sec) | size (minified+gzip bytes)<sup>1</sup> |
|---|---|---|
|  `master`<sup>2</sup> | 138-141K | 132 |
| `v9` | 209-221K | 247 |
| `uuidToBytes_concise` | 146-170K | 125 |
| `uuidToBytes_fast` | 228-230K | 183 |

Thoughts?  Pick one, I guess.  :-)

1.  "size" is for just the `uuidToBytes()` implementation run through `jsmin | gzip -c | wc -c`
2. `master` implementation does not currently `validate()` like the other approaches mentioned here do.