### PR TITLE
Export uuid as default as well

### DIFF
--- a/wrapper.mjs
+++ b/wrapper.mjs
@@ -1,4 +1,7 @@
 import uuid from './dist/index.js';
+
+export default uuid;
+
 export const v1 = uuid.v1;
 export const v3 = uuid.v3;
 export const v4 = uuid.v4;


### PR DESCRIPTION
This allows people to do:

```js
import uuid from 'uuid';
uuid.v4();
```

It also [helps with this Jest issue](https://stackoverflow.com/a/62210156/938236), but I think allowing for the above on itself is merit enough for this PR.

<!--
Thank you for your contribution!

If your pull request contains considerable changes please run the benchmark before and after your
changes and include the results in the pull request description. To run the benchmark execute:

    npm run test:benchmark

from the root of this repository.
-->
