### PR TITLE
test: remove flaky Edge 18.0 on Windows 10 test

### DIFF
--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -75,13 +75,6 @@ const capabilities = [
   {
     ...commonCapabilities,
     browserName: 'Edge',
-    browser_version: '18.0',
-    os: 'Windows',
-    os_version: '10',
-  },
-  {
-    ...commonCapabilities,
-    browserName: 'Edge',
     browser_version: '15.0',
     os: 'Windows',
     os_version: '10',


### PR DESCRIPTION
Browserstack seems to have trouble accessing the local proxy on recent
Edge 18.0 / Windows 10 machines. Since Edge 18.0 is deprecated anyways
and since we still have an Edge 15.0 test as a safety net it should be
fine to just drop the Edge 18.0 test.

<!--
Thank you for your contribution!

If your pull request contains considerable changes please run the benchmark before and after your
changes and include the results in the pull request description. To run the benchmark execute:

    npm run test:benchmark

from the root of this repository.
-->
