### PR TITLE
feat: load env vars from .env file (development feature)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 browserstack.err
 local.log
 *.tgz
+.env

--- a/examples/browser-rollup/package-lock.json
+++ b/examples/browser-rollup/package-lock.json
@@ -315,7 +315,17 @@
       }
     },
     "uuid": {
-      "version": "file:../../.local"
+      "version": "file:../../.local",
+      "requires": {
+        "dotenv": "8.2.0"
+      },
+      "dependencies": {
+        "dotenv": {
+          "version": "8.2.0",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+          "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
+        }
+      }
     }
   }
 }

--- a/examples/browser-webpack/package-lock.json
+++ b/examples/browser-webpack/package-lock.json
@@ -2476,7 +2476,17 @@
       "dev": true
     },
     "uuid": {
-      "version": "file:../../.local"
+      "version": "file:../../.local",
+      "requires": {
+        "dotenv": "8.2.0"
+      },
+      "dependencies": {
+        "dotenv": {
+          "version": "8.2.0",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+          "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
+        }
+      }
     },
     "v8-compile-cache": {
       "version": "2.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6577,6 +6577,11 @@
         "is-obj": "^1.0.0"
       }
     },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
+    },
     "dotgitignore": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/dotgitignore/-/dotgitignore-2.1.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6580,7 +6580,8 @@
     "dotenv": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
-      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
+      "dev": true
     },
     "dotgitignore": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -127,5 +127,8 @@
     "scripts": {
       "postchangelog": "prettier --write CHANGELOG.md"
     }
+  },
+  "dependencies": {
+    "dotenv": "8.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@wdio/sync": "6.1.14",
     "babel-eslint": "10.1.0",
     "bundlewatch": "0.2.7",
+    "dotenv": "8.2.0",
     "eslint": "7.3.0",
     "eslint-config-prettier": "6.11.0",
     "eslint-config-standard": "14.1.1",
@@ -127,8 +128,5 @@
     "scripts": {
       "postchangelog": "prettier --write CHANGELOG.md"
     }
-  },
-  "dependencies": {
-    "dotenv": "8.2.0"
   }
 }

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -1,5 +1,9 @@
 /* eslint-disable camelcase */
 
+// To allow BROWSERSTACK_USER & BROWSERSTACK_ACCESS_KEY to be defined in `.env`
+// file
+require('dotenv').config();
+
 const PORT = 9000;
 const PROJECT = process.env.GITHUB_REPOSITORY || 'node-uuid';
 const GITHUB_SHA = process.env.GITHUB_SHA || '';


### PR DESCRIPTION
Enables `.env` file support for wdio.  (This lets me use my alternate browserstack account for this project, without affecting other projects).

To test: create a `.env` file in project root that looks something like this:
```
BROWSERSTACK_USER=your_user_name
BROWSERSTACK_ACCESS_KEY=your_access_key
```