### PR TITLE
chore: run npm audit fix to satisfy dependabot

### DIFF
--- a/examples/benchmark/package-lock.json
+++ b/examples/benchmark/package-lock.json
@@ -15,9 +15,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true
     },
     "platform": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1107,41 +1107,32 @@
       }
     },
     "@commitlint/cli": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-9.0.1.tgz",
-      "integrity": "sha512-BVOc/BY0FMmKTTH5oUVE0ukhPWDFf364FiYKk3GlXLOGTZPTXQ/9ncB2eMOaCF0PdcEVY4VoMjyoRSgcVapCMg==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-9.1.2.tgz",
+      "integrity": "sha512-ctRrrPqjZ8r4Vc4FXpPaScEpkPwfvB0Us3NK2SD2AnLwXGMxOLFTabDmNySU1Xc40ud2CmJsaV8lpavvzs8ZZA==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.9.6",
-        "@commitlint/format": "^9.0.1",
-        "@commitlint/lint": "^9.0.1",
-        "@commitlint/load": "^9.0.1",
-        "@commitlint/read": "^9.0.1",
-        "chalk": "3.0.0",
+        "@commitlint/format": "^9.1.2",
+        "@commitlint/lint": "^9.1.2",
+        "@commitlint/load": "^9.1.2",
+        "@commitlint/read": "^9.1.2",
+        "chalk": "4.1.0",
         "core-js": "^3.6.1",
         "get-stdin": "7.0.0",
-        "lodash": "^4.17.15",
-        "meow": "5.0.0",
-        "regenerator-runtime": "0.13.3",
+        "lodash": "^4.17.19",
         "resolve-from": "5.0.0",
-        "resolve-global": "1.0.0"
+        "resolve-global": "1.0.0",
+        "yargs": "^15.1.0"
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.10.3",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.3.tgz",
-          "integrity": "sha512-RzGO0RLSdokm9Ipe/YD+7ww8X2Ro79qiXZF3HU9ljrM+qnJmH1Vqth+hbiQZy761LnMJTMitHDuKVYTk3k4dLw==",
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.5.tgz",
+          "integrity": "sha512-otddXKhdNn7d0ptoFRHtMLa8LqDxLYwTjB4nYgM1yy5N6gU/MUf8zqyyLltCH3yAVitBzmwK4us+DD0l/MauAg==",
           "dev": true,
           "requires": {
             "regenerator-runtime": "^0.13.4"
-          },
-          "dependencies": {
-            "regenerator-runtime": {
-              "version": "0.13.5",
-              "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-              "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
-              "dev": true
-            }
           }
         },
         "ansi-styles": {
@@ -1155,9 +1146,9 @@
           }
         },
         "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -1206,28 +1197,29 @@
       }
     },
     "@commitlint/ensure": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-9.0.1.tgz",
-      "integrity": "sha512-z8SEkfbn0lMnAtt7Hp3A8hE3CRCDsg+Eu3Xj1UJakOyCPJgHE1/vEyM2DO2dxTXVKuttiHeLDnUSHCxklm78Ng==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-9.1.2.tgz",
+      "integrity": "sha512-hwQICwpNSTsZgj/1/SdPvYAzhwjwgCJI4vLbT879+Jc+AJ6sj2bUDGw/F89vzgKz1VnaMm4D65bNhoWhG3pdhQ==",
       "dev": true,
       "requires": {
-        "@commitlint/types": "^9.0.1",
-        "lodash": "^4.17.15"
+        "@commitlint/types": "^9.1.2",
+        "lodash": "^4.17.19"
       }
     },
     "@commitlint/execute-rule": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-9.0.1.tgz",
-      "integrity": "sha512-fxnLadXs59qOBE9dInfQjQ4DmbGToQ0NjfqqmN6N8qS+KsCecO6N0mMUrC95et9xTeimFRr+0l9UMfmRVHNS/w==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-9.1.2.tgz",
+      "integrity": "sha512-NGbeo0KCVYo1yj9vVPFHv6RGFpIF6wcQxpFYUKGIzZVV9Vz1WyiKS689JXa99Dt1aN0cZlEJJLnTNDIgYls0Vg==",
       "dev": true
     },
     "@commitlint/format": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-9.0.1.tgz",
-      "integrity": "sha512-5oY7Jyve7Bfnx0CdbxFcpRKq92vUANFq3MVbz/ZTgvuYgUeMuYsSEwW6MJtOgOhHBQ2vZP/uPdxwmU+6pWZHcg==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-9.1.2.tgz",
+      "integrity": "sha512-+ZWTOSGEU6dbn3NRh1q7sY5K5QLiSs7E2uSzuYnWHXcQk8nlTvnE0ibwMCQxdKLaOTZiN57fHM/7M9Re2gsRuw==",
       "dev": true,
       "requires": {
-        "chalk": "^3.0.0"
+        "@commitlint/types": "^9.1.2",
+        "chalk": "^4.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -1241,9 +1233,9 @@
           }
         },
         "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -1283,47 +1275,47 @@
       }
     },
     "@commitlint/is-ignored": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-9.0.1.tgz",
-      "integrity": "sha512-doGBfQgbsi48Hc48runGdN0TQFvf5XZizck8cylQdGG/3w+YwX9WkplEor7cvz8pmmuD6PpfpdukHSKlR8KmHQ==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-9.1.2.tgz",
+      "integrity": "sha512-423W/+Ro+Cc8cg81+t9gds1EscMZNjnGT31nKDvxVxJxXiXQsYYoFEQbU+nfUrRGQsUikEgEJ3ppVGr1linvcQ==",
       "dev": true,
       "requires": {
-        "@commitlint/types": "^9.0.1",
-        "semver": "7.1.3"
+        "@commitlint/types": "^9.1.2",
+        "semver": "7.3.2"
       },
       "dependencies": {
         "semver": {
-          "version": "7.1.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.1.3.tgz",
-          "integrity": "sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA==",
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
           "dev": true
         }
       }
     },
     "@commitlint/lint": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-9.0.1.tgz",
-      "integrity": "sha512-EAn4E6aGWZ96Dg9LN28kdELqkyFOAUGlXWmanMdWxGFGdOf24ZHzlVsbr/Yb1oSBUE2KVvAF5W2Mzn2+Ge5rOg==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-9.1.2.tgz",
+      "integrity": "sha512-XvggqHZ4XSTKOgzJhCzz52cWRRO57QQnEviwGj0qnD4jdwC+8h2u9LNZwoa2tGAuaNM3nSm//wNK7FRZhgiiFA==",
       "dev": true,
       "requires": {
-        "@commitlint/is-ignored": "^9.0.1",
-        "@commitlint/parse": "^9.0.1",
-        "@commitlint/rules": "^9.0.1",
-        "@commitlint/types": "^9.0.1"
+        "@commitlint/is-ignored": "^9.1.2",
+        "@commitlint/parse": "^9.1.2",
+        "@commitlint/rules": "^9.1.2",
+        "@commitlint/types": "^9.1.2"
       }
     },
     "@commitlint/load": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-9.0.1.tgz",
-      "integrity": "sha512-6ix/pUjVAggmDLTcnpyk0bgY3H9UBBTsEeFvTkHV+WQ6LNIxsQk8SwEOEZzWHUqt0pxqMQeiUgYeSZsSw2+uiw==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-9.1.2.tgz",
+      "integrity": "sha512-FPL82xBuF7J3EJ57kLVoligQP4BFRwrknooP+vNT787AXmQ/Fddc/iYYwHwy67pNkk5N++/51UyDl/CqiHb6nA==",
       "dev": true,
       "requires": {
-        "@commitlint/execute-rule": "^9.0.1",
-        "@commitlint/resolve-extends": "^9.0.1",
-        "@commitlint/types": "^9.0.1",
-        "chalk": "3.0.0",
+        "@commitlint/execute-rule": "^9.1.2",
+        "@commitlint/resolve-extends": "^9.1.2",
+        "@commitlint/types": "^9.1.2",
+        "chalk": "4.1.0",
         "cosmiconfig": "^6.0.0",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.19",
         "resolve-from": "^5.0.0"
       },
       "dependencies": {
@@ -1338,9 +1330,9 @@
           }
         },
         "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -1380,15 +1372,15 @@
       }
     },
     "@commitlint/message": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-9.0.1.tgz",
-      "integrity": "sha512-9rKnOeBV5s5hnV895aE3aMgciC27kAjkV9BYVQOWRjZdXHFZxa+OZ94mkMp+Hcr61W++fox1JJpPiTuCTDX3TQ==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-9.1.2.tgz",
+      "integrity": "sha512-ndlx5z7bPVLG347oYJUHuQ41eTcsw+aUYT1ZwQyci0Duy2atpuoeeSw9SuM1PjufzRCpb6ExzFEgGzcCRKAJsg==",
       "dev": true
     },
     "@commitlint/parse": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-9.0.1.tgz",
-      "integrity": "sha512-O39yMSMFdBtqwyM5Ld7RT6OGeI7jiXB9UUb09liIXIkltaZZo6CeoBD9hyfRWpaw81SiGL4OwHzp92mYVHLmow==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-9.1.2.tgz",
+      "integrity": "sha512-d+/VYbkotctW+lzDpus/R6xTerOqFQkW1myH+3PwnqYSE6JU/uHT4MlZNGJBv8pX9SPlR66t6X9puFobqtezEw==",
       "dev": true,
       "requires": {
         "conventional-changelog-angular": "^5.0.0",
@@ -1396,12 +1388,12 @@
       }
     },
     "@commitlint/read": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-9.0.1.tgz",
-      "integrity": "sha512-EYbel85mAiHb56bS5jBJ71lEaGjTnkSJLxTV1u6dpxdSBkRdmAn2DSPd6KQSbwYGUlPCR+pAZeZItT1y0Xk3hg==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-9.1.2.tgz",
+      "integrity": "sha512-C2sNBQOqeQXMxpWtRnXYKYB3D9yuybPtQNY/P67A6o8XH/UMHkFaUTyIx1KRgu0IG0yTTItRt46FGnsMWLotvA==",
       "dev": true,
       "requires": {
-        "@commitlint/top-level": "^9.0.1",
+        "@commitlint/top-level": "^9.1.2",
         "fs-extra": "^8.1.0",
         "git-raw-commits": "^2.0.0"
       },
@@ -1441,39 +1433,39 @@
       }
     },
     "@commitlint/resolve-extends": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-9.0.1.tgz",
-      "integrity": "sha512-o6Lya2ILg1tEfWatS5x8w4ImvDzwb1whxsr2c/cxVCFqLF4hxHHHniZ0NJ+HFhYa1kBsYeKlD1qn9fHX5Y1+PQ==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-9.1.2.tgz",
+      "integrity": "sha512-HcoL+qFGmWEu9VM4fY0HI+VzF4yHcg3x+9Hx6pYFZ+r2wLbnKs964y0v68oyMO/mS/46MVoLNXZGR8U3adpadg==",
       "dev": true,
       "requires": {
         "import-fresh": "^3.0.0",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.19",
         "resolve-from": "^5.0.0",
         "resolve-global": "^1.0.0"
       }
     },
     "@commitlint/rules": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-9.0.1.tgz",
-      "integrity": "sha512-K9IiQzF/C2tP/0mQUPSkOtmAEUleRQhZK1NFLVbsd6r4uobaczjPSYvEH+cuSHlD9b3Ori7PRiTgVBAZTH5ORQ==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-9.1.2.tgz",
+      "integrity": "sha512-1vecFuzqVqjiT57ocXq1bL8V6GEF1NZs3BR0dQzObaqHftImIxBVII299gasckTkcuxNc8M+7XxZyKxUthukpQ==",
       "dev": true,
       "requires": {
-        "@commitlint/ensure": "^9.0.1",
-        "@commitlint/message": "^9.0.1",
-        "@commitlint/to-lines": "^9.0.1",
-        "@commitlint/types": "^9.0.1"
+        "@commitlint/ensure": "^9.1.2",
+        "@commitlint/message": "^9.1.2",
+        "@commitlint/to-lines": "^9.1.2",
+        "@commitlint/types": "^9.1.2"
       }
     },
     "@commitlint/to-lines": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-9.0.1.tgz",
-      "integrity": "sha512-FHiXPhFgGnvekF4rhyl1daHimEHkr81pxbHAmWG/0SOCehFr5THsWGoUYNNBMF7rdwUuVq4tXJpEOFiWBGKigg==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-9.1.2.tgz",
+      "integrity": "sha512-o4zWcMf9EnzA3MOqx01780SgrKq5hqDJmUBPk30g6an0XcDuDy3OSZHHTJFdzsg4V9FjC4OY44sFeK7GN7NaxQ==",
       "dev": true
     },
     "@commitlint/top-level": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-9.0.1.tgz",
-      "integrity": "sha512-AjCah5y7wu9F/hOwMnqsujPRWlKerX79ZGf+UfBpOdAh+USdV7a/UfQaqjgCzkxy5GcNO9ER5A+2mWrUHxJ0hQ==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-9.1.2.tgz",
+      "integrity": "sha512-KMPP5xVePcz3B1dKqcZdU4FZBVOkT+bG3ip4RQX2TeCJoomMkTjd0utALs7rpTGLID6BXbwwXepZCZJREjR/Bw==",
       "dev": true,
       "requires": {
         "find-up": "^4.0.0"
@@ -1531,9 +1523,9 @@
       }
     },
     "@commitlint/types": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-9.0.1.tgz",
-      "integrity": "sha512-wo2rHprtDzTHf4tiSxavktJ52ntiwmg7eHNGFLH38G1of8OfGVwOc1sVbpM4jN/HK/rCMhYOi6xzoPqsv0537A==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-9.1.2.tgz",
+      "integrity": "sha512-r3fwVbVH+M8W0qYlBBZFsUwKe6NT5qvz+EmU7sr8VeN1cQ63z+3cfXyTo7WGGEMEgKiT0jboNAK3b1FZp8k9LQ==",
       "dev": true
     },
     "@istanbuljs/load-nyc-config": {
@@ -5339,22 +5331,35 @@
       "dev": true
     },
     "conventional-changelog": {
-      "version": "3.1.18",
-      "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-3.1.18.tgz",
-      "integrity": "sha512-aN6a3rjgV8qwAJj3sC/Lme2kvswWO7fFSGQc32gREcwIOsaiqBaO6f2p0NomFaPDnTqZ+mMZFLL3hlzvEnZ0mQ==",
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-3.1.21.tgz",
+      "integrity": "sha512-ZGecVZPEo3aC75VVE4nu85589dDhpMyqfqgUM5Myq6wfKWiNqhDJLSDMsc8qKXshZoY7dqs1hR0H/15kI/G2jQ==",
       "dev": true,
       "requires": {
-        "conventional-changelog-angular": "^5.0.6",
-        "conventional-changelog-atom": "^2.0.3",
-        "conventional-changelog-codemirror": "^2.0.3",
-        "conventional-changelog-conventionalcommits": "^4.2.3",
-        "conventional-changelog-core": "^4.1.4",
-        "conventional-changelog-ember": "^2.0.4",
-        "conventional-changelog-eslint": "^3.0.4",
-        "conventional-changelog-express": "^2.0.1",
-        "conventional-changelog-jquery": "^3.0.6",
-        "conventional-changelog-jshint": "^2.0.3",
-        "conventional-changelog-preset-loader": "^2.3.0"
+        "conventional-changelog-angular": "^5.0.10",
+        "conventional-changelog-atom": "^2.0.7",
+        "conventional-changelog-codemirror": "^2.0.7",
+        "conventional-changelog-conventionalcommits": "^4.3.0",
+        "conventional-changelog-core": "^4.1.7",
+        "conventional-changelog-ember": "^2.0.8",
+        "conventional-changelog-eslint": "^3.0.8",
+        "conventional-changelog-express": "^2.0.5",
+        "conventional-changelog-jquery": "^3.0.10",
+        "conventional-changelog-jshint": "^2.0.7",
+        "conventional-changelog-preset-loader": "^2.3.4"
+      },
+      "dependencies": {
+        "conventional-changelog-conventionalcommits": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.3.0.tgz",
+          "integrity": "sha512-oYHydvZKU+bS8LnGqTMlNrrd7769EsuEHKy4fh1oMdvvDi7fem8U+nvfresJ1IDB8K00Mn4LpiA/lR+7Gs6rgg==",
+          "dev": true,
+          "requires": {
+            "compare-func": "^1.3.1",
+            "lodash": "^4.17.15",
+            "q": "^1.5.1"
+          }
+        }
       }
     },
     "conventional-changelog-angular": {
@@ -5482,210 +5487,6 @@
             }
           }
         },
-        "git-semver-tags": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-4.0.0.tgz",
-          "integrity": "sha512-LajaAWLYVBff+1NVircURJFL8TQ3EMIcLAfHisWYX/nPoMwnTYfWAznQDmMujlLqoD12VtLmoSrF1sQ5MhimEQ==",
-          "dev": true,
-          "requires": {
-            "meow": "^7.0.0",
-            "semver": "^6.0.0"
-          },
-          "dependencies": {
-            "arrify": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-              "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
-              "dev": true
-            },
-            "camelcase": {
-              "version": "6.0.0",
-              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
-              "integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==",
-              "dev": true
-            },
-            "camelcase-keys": {
-              "version": "6.2.2",
-              "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
-              "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
-              "dev": true,
-              "requires": {
-                "camelcase": "^5.3.1",
-                "map-obj": "^4.0.0",
-                "quick-lru": "^4.0.1"
-              },
-              "dependencies": {
-                "camelcase": {
-                  "version": "5.3.1",
-                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-                  "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-                  "dev": true
-                }
-              }
-            },
-            "find-up": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-              "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-              "dev": true,
-              "requires": {
-                "locate-path": "^5.0.0",
-                "path-exists": "^4.0.0"
-              }
-            },
-            "indent-string": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-              "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-              "dev": true
-            },
-            "map-obj": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.1.0.tgz",
-              "integrity": "sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g==",
-              "dev": true
-            },
-            "meow": {
-              "version": "7.0.1",
-              "resolved": "https://registry.npmjs.org/meow/-/meow-7.0.1.tgz",
-              "integrity": "sha512-tBKIQqVrAHqwit0vfuFPY3LlzJYkEOFyKa3bPgxzNl6q/RtN8KQ+ALYEASYuFayzSAsjlhXj/JZ10rH85Q6TUw==",
-              "dev": true,
-              "requires": {
-                "@types/minimist": "^1.2.0",
-                "arrify": "^2.0.1",
-                "camelcase": "^6.0.0",
-                "camelcase-keys": "^6.2.2",
-                "decamelize-keys": "^1.1.0",
-                "hard-rejection": "^2.1.0",
-                "minimist-options": "^4.0.2",
-                "normalize-package-data": "^2.5.0",
-                "read-pkg-up": "^7.0.1",
-                "redent": "^3.0.0",
-                "trim-newlines": "^3.0.0",
-                "type-fest": "^0.13.1",
-                "yargs-parser": "^18.1.3"
-              }
-            },
-            "minimist-options": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
-              "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
-              "dev": true,
-              "requires": {
-                "arrify": "^1.0.1",
-                "is-plain-obj": "^1.1.0",
-                "kind-of": "^6.0.3"
-              },
-              "dependencies": {
-                "arrify": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-                  "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-                  "dev": true
-                }
-              }
-            },
-            "normalize-package-data": {
-              "version": "2.5.0",
-              "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-              "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-              "dev": true,
-              "requires": {
-                "hosted-git-info": "^2.1.4",
-                "resolve": "^1.10.0",
-                "semver": "2 || 3 || 4 || 5",
-                "validate-npm-package-license": "^3.0.1"
-              },
-              "dependencies": {
-                "semver": {
-                  "version": "5.7.1",
-                  "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-                  "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-                  "dev": true
-                }
-              }
-            },
-            "quick-lru": {
-              "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
-              "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
-              "dev": true
-            },
-            "read-pkg": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
-              "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
-              "dev": true,
-              "requires": {
-                "@types/normalize-package-data": "^2.4.0",
-                "normalize-package-data": "^2.5.0",
-                "parse-json": "^5.0.0",
-                "type-fest": "^0.6.0"
-              },
-              "dependencies": {
-                "type-fest": {
-                  "version": "0.6.0",
-                  "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-                  "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
-                  "dev": true
-                }
-              }
-            },
-            "read-pkg-up": {
-              "version": "7.0.1",
-              "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
-              "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
-              "dev": true,
-              "requires": {
-                "find-up": "^4.1.0",
-                "read-pkg": "^5.2.0",
-                "type-fest": "^0.8.1"
-              },
-              "dependencies": {
-                "type-fest": {
-                  "version": "0.8.1",
-                  "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-                  "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-                  "dev": true
-                }
-              }
-            },
-            "redent": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
-              "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
-              "dev": true,
-              "requires": {
-                "indent-string": "^4.0.0",
-                "strip-indent": "^3.0.0"
-              }
-            },
-            "strip-indent": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
-              "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
-              "dev": true,
-              "requires": {
-                "min-indent": "^1.0.0"
-              }
-            },
-            "trim-newlines": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.0.tgz",
-              "integrity": "sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==",
-              "dev": true
-            }
-          }
-        },
-        "locate-path": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^4.1.0"
-          }
-        },
         "map-obj": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
@@ -5719,48 +5520,6 @@
             "is-plain-obj": "^1.1.0"
           }
         },
-        "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-          "dev": true,
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.2.0"
-          }
-        },
-        "p-try": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-          "dev": true
-        },
-        "parse-json": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
-          "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1",
-            "lines-and-columns": "^1.1.6"
-          }
-        },
-        "path-exists": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-          "dev": true
-        },
         "quick-lru": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
@@ -5786,12 +5545,6 @@
             "indent-string": "^3.0.0",
             "strip-indent": "^2.0.0"
           }
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
         },
         "strip-indent": {
           "version": "2.0.0",
@@ -5835,9 +5588,9 @@
       }
     },
     "conventional-changelog-jquery": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-jquery/-/conventional-changelog-jquery-3.0.6.tgz",
-      "integrity": "sha512-gHAABCXUNA/HjnZEm+vxAfFPJkgtrZvCDIlCKfdPVXtCIo/Q0lN5VKpx8aR5p8KdVRQFF3OuTlvv5kv6iPuRqA==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-jquery/-/conventional-changelog-jquery-3.0.10.tgz",
+      "integrity": "sha512-QCW6wF8QgPkq2ruPaxc83jZxoWQxLkt/pNxIDn/oYjMiVgrtqNdd7lWe3vsl0hw5ENHNf/ejXuzDHk6suKsRpg==",
       "dev": true,
       "requires": {
         "q": "^1.5.1"
@@ -5996,18 +5749,18 @@
       }
     },
     "conventional-recommended-bump": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-6.0.5.tgz",
-      "integrity": "sha512-srkferrB4kACPEbKYltZwX1CQZAEqbQkabKN444mavLRVMetzwJFJf23/+pwvtMsWbd+cc4HaleV1nHke0f8Rw==",
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-6.0.9.tgz",
+      "integrity": "sha512-DpRmW1k8CpRrcsXHOPGgHgOd4BMGiq2gtXAveGM8B9pSd9b4r4WKnqp1Fd0vkDtk8l973mIk8KKKUYnKRr9SFw==",
       "dev": true,
       "requires": {
         "concat-stream": "^2.0.0",
-        "conventional-changelog-preset-loader": "^2.3.0",
-        "conventional-commits-filter": "^2.0.2",
-        "conventional-commits-parser": "^3.0.8",
+        "conventional-changelog-preset-loader": "^2.3.4",
+        "conventional-commits-filter": "^2.0.6",
+        "conventional-commits-parser": "^3.1.0",
         "git-raw-commits": "2.0.0",
-        "git-semver-tags": "^3.0.1",
-        "meow": "^5.0.0",
+        "git-semver-tags": "^4.0.0",
+        "meow": "^7.0.0",
         "q": "^1.5.1"
       },
       "dependencies": {
@@ -6075,11 +5828,197 @@
             }
           }
         },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
         "map-obj": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
           "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
           "dev": true
+        },
+        "meow": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-7.0.1.tgz",
+          "integrity": "sha512-tBKIQqVrAHqwit0vfuFPY3LlzJYkEOFyKa3bPgxzNl6q/RtN8KQ+ALYEASYuFayzSAsjlhXj/JZ10rH85Q6TUw==",
+          "dev": true,
+          "requires": {
+            "@types/minimist": "^1.2.0",
+            "arrify": "^2.0.1",
+            "camelcase": "^6.0.0",
+            "camelcase-keys": "^6.2.2",
+            "decamelize-keys": "^1.1.0",
+            "hard-rejection": "^2.1.0",
+            "minimist-options": "^4.0.2",
+            "normalize-package-data": "^2.5.0",
+            "read-pkg-up": "^7.0.1",
+            "redent": "^3.0.0",
+            "trim-newlines": "^3.0.0",
+            "type-fest": "^0.13.1",
+            "yargs-parser": "^18.1.3"
+          },
+          "dependencies": {
+            "arrify": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+              "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+              "dev": true
+            },
+            "camelcase": {
+              "version": "6.0.0",
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
+              "integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==",
+              "dev": true
+            },
+            "camelcase-keys": {
+              "version": "6.2.2",
+              "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+              "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+              "dev": true,
+              "requires": {
+                "camelcase": "^5.3.1",
+                "map-obj": "^4.0.0",
+                "quick-lru": "^4.0.1"
+              },
+              "dependencies": {
+                "camelcase": {
+                  "version": "5.3.1",
+                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+                  "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+                  "dev": true
+                }
+              }
+            },
+            "find-up": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+              "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+              "dev": true,
+              "requires": {
+                "locate-path": "^5.0.0",
+                "path-exists": "^4.0.0"
+              }
+            },
+            "indent-string": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+              "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+              "dev": true
+            },
+            "map-obj": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.1.0.tgz",
+              "integrity": "sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g==",
+              "dev": true
+            },
+            "minimist-options": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
+              "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
+              "dev": true,
+              "requires": {
+                "arrify": "^1.0.1",
+                "is-plain-obj": "^1.1.0",
+                "kind-of": "^6.0.3"
+              },
+              "dependencies": {
+                "arrify": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+                  "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+                  "dev": true
+                }
+              }
+            },
+            "normalize-package-data": {
+              "version": "2.5.0",
+              "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+              "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+              "dev": true,
+              "requires": {
+                "hosted-git-info": "^2.1.4",
+                "resolve": "^1.10.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
+              }
+            },
+            "quick-lru": {
+              "version": "4.0.1",
+              "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
+              "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
+              "dev": true
+            },
+            "read-pkg": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+              "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+              "dev": true,
+              "requires": {
+                "@types/normalize-package-data": "^2.4.0",
+                "normalize-package-data": "^2.5.0",
+                "parse-json": "^5.0.0",
+                "type-fest": "^0.6.0"
+              },
+              "dependencies": {
+                "type-fest": {
+                  "version": "0.6.0",
+                  "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+                  "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+                  "dev": true
+                }
+              }
+            },
+            "read-pkg-up": {
+              "version": "7.0.1",
+              "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+              "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+              "dev": true,
+              "requires": {
+                "find-up": "^4.1.0",
+                "read-pkg": "^5.2.0",
+                "type-fest": "^0.8.1"
+              },
+              "dependencies": {
+                "type-fest": {
+                  "version": "0.8.1",
+                  "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+                  "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+                  "dev": true
+                }
+              }
+            },
+            "redent": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+              "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+              "dev": true,
+              "requires": {
+                "indent-string": "^4.0.0",
+                "strip-indent": "^3.0.0"
+              }
+            },
+            "strip-indent": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+              "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+              "dev": true,
+              "requires": {
+                "min-indent": "^1.0.0"
+              }
+            },
+            "trim-newlines": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.0.tgz",
+              "integrity": "sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==",
+              "dev": true
+            }
+          }
         },
         "minimist-options": {
           "version": "3.0.2",
@@ -6090,6 +6029,48 @@
             "arrify": "^1.0.1",
             "is-plain-obj": "^1.1.0"
           }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "parse-json": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
+          "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1",
+            "lines-and-columns": "^1.1.6"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
         },
         "quick-lru": {
           "version": "1.1.0",
@@ -8310,6 +8291,34 @@
         "meow": "^7.0.0",
         "split2": "^2.0.0",
         "through2": "^3.0.0"
+      }
+    },
+    "git-remote-origin-url": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
+      "integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
+      "dev": true,
+      "requires": {
+        "gitconfiglocal": "^1.0.0",
+        "pify": "^2.3.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
+      }
+    },
+    "git-semver-tags": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-4.0.0.tgz",
+      "integrity": "sha512-LajaAWLYVBff+1NVircURJFL8TQ3EMIcLAfHisWYX/nPoMwnTYfWAznQDmMujlLqoD12VtLmoSrF1sQ5MhimEQ==",
+      "dev": true,
+      "requires": {
+        "meow": "^7.0.0",
+        "semver": "^6.0.0"
       },
       "dependencies": {
         "meow": {
@@ -8343,38 +8352,16 @@
             "resolve": "^1.10.0",
             "semver": "2 || 3 || 4 || 5",
             "validate-npm-package-license": "^3.0.1"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "5.7.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+              "dev": true
+            }
           }
-        }
-      }
-    },
-    "git-remote-origin-url": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
-      "integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
-      "dev": true,
-      "requires": {
-        "gitconfiglocal": "^1.0.0",
-        "pify": "^2.3.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        }
-      }
-    },
-    "git-semver-tags": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-3.0.1.tgz",
-      "integrity": "sha512-Hzd1MOHXouITfCasrpVJbRDg9uvW7LfABk3GQmXYZByerBDrfrEMP9HXpNT7RxAbieiocP6u+xq20DkvjwxnCA==",
-      "dev": true,
-      "requires": {
-        "meow": "^5.0.0",
-        "semver": "^6.0.0"
-      },
-      "dependencies": {
+        },
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -12566,9 +12553,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true
     },
     "lodash._reinterpolate": {
@@ -12932,106 +12919,36 @@
       "dev": true
     },
     "meow": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-5.0.0.tgz",
-      "integrity": "sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-7.0.1.tgz",
+      "integrity": "sha512-tBKIQqVrAHqwit0vfuFPY3LlzJYkEOFyKa3bPgxzNl6q/RtN8KQ+ALYEASYuFayzSAsjlhXj/JZ10rH85Q6TUw==",
       "dev": true,
       "requires": {
-        "camelcase-keys": "^4.0.0",
-        "decamelize-keys": "^1.0.0",
-        "loud-rejection": "^1.0.0",
-        "minimist-options": "^3.0.1",
-        "normalize-package-data": "^2.3.4",
-        "read-pkg-up": "^3.0.0",
-        "redent": "^2.0.0",
-        "trim-newlines": "^2.0.0",
-        "yargs-parser": "^10.0.0"
+        "@types/minimist": "^1.2.0",
+        "arrify": "^2.0.1",
+        "camelcase": "^6.0.0",
+        "camelcase-keys": "^6.2.2",
+        "decamelize-keys": "^1.1.0",
+        "hard-rejection": "^2.1.0",
+        "minimist-options": "^4.0.2",
+        "normalize-package-data": "^2.5.0",
+        "read-pkg-up": "^7.0.1",
+        "redent": "^3.0.0",
+        "trim-newlines": "^3.0.0",
+        "type-fest": "^0.13.1",
+        "yargs-parser": "^18.1.3"
       },
       "dependencies": {
-        "arrify": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-          "dev": true
-        },
-        "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-          "dev": true
-        },
-        "camelcase-keys": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
-          "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
+        "normalize-package-data": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+          "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
           "dev": true,
           "requires": {
-            "camelcase": "^4.1.0",
-            "map-obj": "^2.0.0",
-            "quick-lru": "^1.0.0"
-          }
-        },
-        "map-obj": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
-          "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
-          "dev": true
-        },
-        "minimist-options": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
-          "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
-          "dev": true,
-          "requires": {
-            "arrify": "^1.0.1",
-            "is-plain-obj": "^1.1.0"
-          }
-        },
-        "quick-lru": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
-          "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
-          "dev": true
-        },
-        "read-pkg-up": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
-          "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
-          "dev": true,
-          "requires": {
-            "find-up": "^2.0.0",
-            "read-pkg": "^3.0.0"
-          }
-        },
-        "redent": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
-          "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
-          "dev": true,
-          "requires": {
-            "indent-string": "^3.0.0",
-            "strip-indent": "^2.0.0"
-          }
-        },
-        "strip-indent": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
-          "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
-          "dev": true
-        },
-        "trim-newlines": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
-          "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
-          "dev": true
-        },
-        "yargs-parser": {
-          "version": "10.1.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
-          "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
-          "dev": true,
-          "requires": {
-            "camelcase": "^4.1.0"
+            "hosted-git-info": "^2.1.4",
+            "resolve": "^1.10.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
           }
         }
       }
@@ -13283,9 +13200,9 @@
       "dev": true
     },
     "neo-async": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
     "nice-try": {
@@ -14145,6 +14062,15 @@
         "json-stringify-safe": "^5.0.1"
       }
     },
+    "randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
     "range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -14368,9 +14294,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+      "version": "0.13.6",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.6.tgz",
+      "integrity": "sha512-GmwlGiazQEbOwQWDdbbaP10i15pGtScYWLbMZuu+RKRz0cZ+g8IUONazBnaZqe7j1670IV1HgE4/8iy7CQPf4Q==",
       "dev": true
     },
     "regenerator-transform": {
@@ -15263,26 +15189,26 @@
       "dev": true
     },
     "standard-version": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/standard-version/-/standard-version-8.0.0.tgz",
-      "integrity": "sha512-cS/U9yhYPHfyokFce6e/H3U8MaKwZKSGzH25J776sChrae/doDQjsl3vCQ0hW1MSzdrUTb7pir4ApjnbDt/TAg==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/standard-version/-/standard-version-8.0.2.tgz",
+      "integrity": "sha512-L8X9KFq2SmVmaeZgUmWHFJMOsEWpjgFAwqic6yIIoveM1kdw1vH4Io03WWxUDjypjGqGU6qUtcJoR8UvOv5w3g==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.2",
-        "conventional-changelog": "3.1.18",
+        "chalk": "^2.4.2",
+        "conventional-changelog": "3.1.21",
         "conventional-changelog-config-spec": "2.1.0",
-        "conventional-changelog-conventionalcommits": "4.2.3",
-        "conventional-recommended-bump": "6.0.5",
-        "detect-indent": "6.0.0",
-        "detect-newline": "3.1.0",
-        "dotgitignore": "2.1.0",
-        "figures": "3.1.0",
-        "find-up": "4.1.0",
-        "fs-access": "1.0.1",
-        "git-semver-tags": "3.0.1",
-        "semver": "7.1.1",
-        "stringify-package": "1.0.1",
-        "yargs": "15.3.1"
+        "conventional-changelog-conventionalcommits": "4.3.0",
+        "conventional-recommended-bump": "6.0.9",
+        "detect-indent": "^6.0.0",
+        "detect-newline": "^3.1.0",
+        "dotgitignore": "^2.1.0",
+        "figures": "^3.1.0",
+        "find-up": "^4.1.0",
+        "fs-access": "^1.0.1",
+        "git-semver-tags": "^4.0.0",
+        "semver": "^7.1.1",
+        "stringify-package": "^1.0.1",
+        "yargs": "^15.3.1"
       },
       "dependencies": {
         "chalk": {
@@ -15296,13 +15222,15 @@
             "supports-color": "^5.3.0"
           }
         },
-        "figures": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-3.1.0.tgz",
-          "integrity": "sha512-ravh8VRXqHuMvZt/d8GblBeqDMkdJMBdv/2KntFH+ra5MXkO7nxNKpzQ3n6QD/2da1kH0aWmNISdvhM7gl2gVg==",
+        "conventional-changelog-conventionalcommits": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.3.0.tgz",
+          "integrity": "sha512-oYHydvZKU+bS8LnGqTMlNrrd7769EsuEHKy4fh1oMdvvDi7fem8U+nvfresJ1IDB8K00Mn4LpiA/lR+7Gs6rgg==",
           "dev": true,
           "requires": {
-            "escape-string-regexp": "^1.0.5"
+            "compare-func": "^1.3.1",
+            "lodash": "^4.17.15",
+            "q": "^1.5.1"
           }
         },
         "find-up": {
@@ -15355,9 +15283,9 @@
           "dev": true
         },
         "semver": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.1.1.tgz",
-          "integrity": "sha512-WfuG+fl6eh3eZ2qAf6goB7nhiCd7NPXhmyFxigB/TOkQyeLP8w8GsVehvtGNtnNmyboz4TgeK40B1Kbql/8c5A==",
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@babel/cli": "7.10.3",
     "@babel/core": "7.10.3",
     "@babel/preset-env": "7.10.3",
-    "@commitlint/cli": "9.0.1",
+    "@commitlint/cli": "9.1.2",
     "@commitlint/config-conventional": "9.0.1",
     "@rollup/plugin-node-resolve": "8.0.1",
     "@wdio/browserstack-service": "6.1.15",
@@ -77,7 +77,7 @@
     "rollup": "2.18.0",
     "rollup-plugin-terser": "6.1.0",
     "runmd": "1.3.2",
-    "standard-version": "8.0.0"
+    "standard-version": "8.0.2"
   },
   "scripts": {
     "examples:browser:webpack:build": "cd examples/browser-webpack && npm install && npm run build",


### PR DESCRIPTION
TBH dependabot is such a shitshow. Bothering us about irrelevant minor security flaws in dev dependencies, that, upon each merge to master, cause 3 pull-requests to be auto-rebased, overwhelming our Browserstack instance, leading to timeouts for tests on master, which I then have to re-run manually.

I have disabled dependabot and I suggest to leave it disabled as long as this library doesn't have any production dependencies.

Or am I missing something?