### PR TITLE
test: increase wdio timout

### DIFF
--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -132,7 +132,7 @@ exports.config = {
   connectionRetryCount: 3,
   framework: 'jasmine',
   jasmineNodeOpts: {
-    defaultTimeoutInterval: 30000,
+    defaultTimeoutInterval: 120000,
   },
   reporters: ['spec'],
 };


### PR DESCRIPTION
With the added tests IE11 tests have become flaky since they simply seem
too sloooooooooooow. The tests in IE11 take up to 1:30 to run while they
usually finish after around 30s in all other browsers.

<!--
Thank you for your contribution!

If your pull request contains considerable changes please run the benchmark before and after your
changes and include the results in the pull request description. To run the benchmark execute:

    npm run test:benchmark

from the root of this repository.
-->
