### PR TITLE
test: optimize browser test order

### DIFF
--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -17,6 +17,22 @@ const commonCapabilities = {
 };
 
 const capabilities = [
+  // IE
+  {
+    ...commonCapabilities,
+    browserName: 'IE',
+    browser_version: '11.0',
+    os: 'Windows',
+    os_version: '10',
+  },
+  {
+    ...commonCapabilities,
+    browserName: 'IE',
+    browser_version: '11.0',
+    os: 'Windows',
+    os_version: '7',
+  },
+
   // Chrome
   {
     ...commonCapabilities,
@@ -49,22 +65,6 @@ const capabilities = [
     os_version: '10',
   },
 
-  // Safari
-  {
-    ...commonCapabilities,
-    browserName: 'Safari',
-    browser_version: '13.0',
-    os: 'OS X',
-    os_version: 'Catalina',
-  },
-  {
-    ...commonCapabilities,
-    browserName: 'Safari',
-    browser_version: '10.0',
-    os: 'OS X',
-    os_version: 'Sierra',
-  },
-
   // Edge
   {
     ...commonCapabilities,
@@ -81,20 +81,20 @@ const capabilities = [
     os_version: '10',
   },
 
-  // IE
+  // Safari
   {
     ...commonCapabilities,
-    browserName: 'IE',
-    browser_version: '11.0',
-    os: 'Windows',
-    os_version: '10',
+    browserName: 'Safari',
+    browser_version: '13.0',
+    os: 'OS X',
+    os_version: 'Catalina',
   },
   {
     ...commonCapabilities,
-    browserName: 'IE',
-    browser_version: '11.0',
-    os: 'Windows',
-    os_version: '7',
+    browserName: 'Safari',
+    browser_version: '10.0',
+    os: 'OS X',
+    os_version: 'Sierra',
   },
 ];
 


### PR DESCRIPTION
Wdio executes tests in order. We have 5 concurrent execution slots at
BrowserStack. Since the IE tests take by far the longest time (1:30
instead of 0:30 for all others) it makes sense to run them first. Safari
tests seem to execute the fastes, so run them last.

<!--
Thank you for your contribution!

If your pull request contains considerable changes please run the benchmark before and after your
changes and include the results in the pull request description. To run the benchmark execute:

    npm run test:benchmark

from the root of this repository.
-->
