### PR TITLE
perf(nodejs): introduce pool into default rng

### DIFF
--- a/src/rng.js
+++ b/src/rng.js
@@ -1,7 +1,6 @@
 import crypto from 'crypto';
 
-const poolSize = 16;
-const rnds8Pool = new Uint8Array(16 * poolSize);
+const rnds8Pool = new Uint8Array(256); // # of random values to pre-allocate
 let poolPtr = rnds8Pool.length;
 
 export default function rng() {

--- a/src/rng.js
+++ b/src/rng.js
@@ -1,7 +1,14 @@
 import crypto from 'crypto';
 
-const rnds8 = new Uint8Array(16);
+const poolSize = 4;
+const rnds8Pool = new Uint8Array(16 * poolSize);
+let poolPtr = -1;
 
 export default function rng() {
-  return crypto.randomFillSync(rnds8);
+  if (poolPtr === -1 || poolPtr === poolSize) {
+    crypto.randomFillSync(rnds8Pool);
+    poolPtr = 0;
+  }
+  const pos = 16 * poolPtr++;
+  return rnds8Pool.slice(pos, pos + 16);
 }

--- a/src/rng.js
+++ b/src/rng.js
@@ -1,14 +1,13 @@
 import crypto from 'crypto';
 
-const poolSize = 4;
+const poolSize = 16;
 const rnds8Pool = new Uint8Array(16 * poolSize);
-let poolPtr = -1;
+let poolPtr = rnds8Pool.length;
 
 export default function rng() {
-  if (poolPtr === -1 || poolPtr === poolSize) {
+  if (poolPtr > rnds8Pool.length - 16) {
     crypto.randomFillSync(rnds8Pool);
     poolPtr = 0;
   }
-  const pos = 16 * poolPtr++;
-  return rnds8Pool.slice(pos, pos + 16);
+  return rnds8Pool.slice(poolPtr, (poolPtr += 16));
 }


### PR DESCRIPTION
<!--
Thank you for your contribution!

If your pull request contains considerable changes please run the benchmark before and after your
changes and include the results in the pull request description. To run the benchmark execute:

    npm run test:benchmark

from the root of this repository.
-->

* Significantly improves v4 performance for the default RNG by introducing batch generation

Benchmark `master` (bc9d4eda7dafce60d503435f09e7cbb0c7384d18):
```
uuidv1() x 1,868,914 ops/sec ±0.26% (92 runs sampled)
uuidv1() fill existing array x 9,711,758 ops/sec ±0.16% (94 runs sampled)
uuidv4() x 412,330 ops/sec ±0.13% (98 runs sampled)
uuidv4() fill existing array x 513,285 ops/sec ±0.16% (93 runs sampled)
uuidv3() x 321,397 ops/sec ±0.57% (91 runs sampled)
uuidv5() x 301,932 ops/sec ±1.08% (90 runs sampled)
Fastest is uuidv1() fill existing array
```

Benchmark this branch (pool size 64):
```
uuidv1() x 1,800,216 ops/sec ±0.80% (96 runs sampled)
uuidv1() fill existing array x 9,679,788 ops/sec ±0.27% (95 runs sampled)
uuidv4() x 819,473 ops/sec ±0.37% (96 runs sampled)
uuidv4() fill existing array x 1,630,070 ops/sec ±0.66% (92 runs sampled)
uuidv3() x 305,889 ops/sec ±0.99% (89 runs sampled)
uuidv5() x 299,425 ops/sec ±0.82% (89 runs sampled)
Fastest is uuidv1() fill existing array
```

Benchmark this branch (pool size 256) - current version:
```
uuidv1() x 1,874,252 ops/sec ±0.29% (97 runs sampled)
uuidv1() fill existing array x 9,641,771 ops/sec ±0.48% (94 runs sampled)
uuidv4() x 1,230,123 ops/sec ±0.63% (93 runs sampled)
uuidv4() fill existing array x 4,377,290 ops/sec ±0.71% (98 runs sampled)
uuidv3() x 317,152 ops/sec ±0.76% (93 runs sampled)
uuidv5() x 308,891 ops/sec ±0.85% (93 runs sampled)
Fastest is uuidv1() fill existing array
```