### PR TITLE
fix: add crypto at dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5115,6 +5115,11 @@
         "which": "^1.2.9"
       }
     },
+    "crypto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
+      "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig=="
+    },
     "cssom": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",

--- a/package.json
+++ b/package.json
@@ -131,5 +131,8 @@
     "scripts": {
       "postchangelog": "prettier --write CHANGELOG.md"
     }
+  },
+  "dependencies": {
+    "crypto": "1.0.1"
   }
 }


### PR DESCRIPTION
## Description

Webpack5 does not automatically install crypto, and an error occurs when building a package that uses uuid.

Since [src/rng.js](https://github.com/uuidjs/uuid/blob/252ebcfb33b2d056963a530fc02067ae3de6095a/src/rng.js#L1) is using crypto, I think it needs to be added to the dependencies.

