### PR TITLE
feat: exports regex as 1st class citizen

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,3 +7,4 @@ export { default as version } from './version.js';
 export { default as validate } from './validate.js';
 export { default as stringify } from './stringify.js';
 export { default as parse } from './parse.js';
+export { default as regex } from './regex.js';


### PR DESCRIPTION
This will help the following use case (and others):

```js
import { regex } from 'uuid';

describe('duck', () => {
  it('quacks', () => {
   const duck = createDuck();
    expect(duck).toEqual({
      name: 'daffy',
      sound: 'quack',
      uuid: expect.stringMatching(regex)
    })
  })
})
```

Importing from dist/esm is not ideal, and proper TS support (I think we'll have to change @types/uuid for this) would be great.