### PR TITLE
lazy-load getRandomValues to mitigate problems with react-native-get-random-values polyfill

### DIFF
--- a/src/rng-browser.js
+++ b/src/rng-browser.js
@@ -2,23 +2,27 @@
 // require the crypto API and do not support built-in fallback to lower quality random number
 // generators (like Math.random()).
 
-// getRandomValues needs to be invoked in a context where "this" is a Crypto implementation. Also,
-// find the complete implementation of crypto (msCrypto) on IE11.
-const getRandomValues =
-  (typeof crypto !== 'undefined' &&
-    crypto.getRandomValues &&
-    crypto.getRandomValues.bind(crypto)) ||
-  (typeof msCrypto !== 'undefined' &&
-    typeof msCrypto.getRandomValues === 'function' &&
-    msCrypto.getRandomValues.bind(msCrypto));
+let getRandomValues;
 
 const rnds8 = new Uint8Array(16);
 
 export default function rng() {
+  // lazy load so that environments that need to polyfill have a chance to do so
   if (!getRandomValues) {
-    throw new Error(
-      'crypto.getRandomValues() not supported. See https://github.com/uuidjs/uuid#getrandomvalues-not-supported'
-    );
+    // getRandomValues needs to be invoked in a context where "this" is a Crypto implementation. Also,
+    // find the complete implementation of crypto (msCrypto) on IE11.
+    getRandomValues =
+      (typeof crypto !== 'undefined' &&
+        crypto.getRandomValues &&
+        crypto.getRandomValues.bind(crypto)) ||
+      (typeof msCrypto !== 'undefined' &&
+        typeof msCrypto.getRandomValues === 'function' &&
+        msCrypto.getRandomValues.bind(msCrypto));
+    if (!getRandomValues) {
+      throw new Error(
+        'crypto.getRandomValues() not supported. See https://github.com/uuidjs/uuid#getrandomvalues-not-supported'
+      );
+    }
   }
 
   return getRandomValues(rnds8);


### PR DESCRIPTION
Here's a PR for the lazy loading fix discussed in #536. This defers the loading and caching of crypto.getRandomValues to first invocation, rather than module load time, helping out React Native clients.

Without this change, RN projects must manage an implicit dependency on react-native-get-random-values, and try to ensure that it gets loaded before uuid does.

With this change, the RN polyfill simply needs to be installed sometime before the first uuid is created.

No significant benchmark differences. (In fact the v4 tests ran slightly faster on my machine with this change, but I'm sure that was accidental.)