### PR TITLE
docs: add examples of per-version validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,23 @@ uuidValidate('not a UUID'); // ⇨ false
 uuidValidate('6ec0bd7f-11c0-43da-975e-2a8ad9ebae0b'); // ⇨ true
 ```
 
+Using `validate` and `version` together it is possible to do per-version validation, e.g. validate for only v4 UUIds.
+
+```javascript
+import { version as uuidVersion } from 'uuid';
+import { validate as uuidValidate } from 'uuid';
+
+function uuidValidateV4(uuid) {
+  return uuidValidate(uuid) && uuidVersion(uuid) === 4;
+}
+
+const v1Uuid = 'd9428888-122b-11e1-b85c-61cd3cbb3210';
+const v4Uuid = '109156be-c4fb-41ea-b1b4-efe1671c5836';
+
+uuidValidateV4(v4Uuid); // ⇨ true
+uuidValidateV4(v1Uuid); // ⇨ false
+```
+
 ### uuid.version(str)
 
 Detect RFC version of a UUID

--- a/README_js.md
+++ b/README_js.md
@@ -302,6 +302,23 @@ uuidValidate('not a UUID'); // RESULT
 uuidValidate('6ec0bd7f-11c0-43da-975e-2a8ad9ebae0b'); // RESULT
 ```
 
+Using `validate` and `version` together it is possible to do per-version validation, e.g. validate for only v4 UUIds.
+
+```javascript --run
+import { version as uuidVersion } from 'uuid';
+import { validate as uuidValidate } from 'uuid';
+
+function uuidValidateV4(uuid) {
+  return uuidValidate(uuid) && uuidVersion(uuid) === 4;
+}
+
+const v1Uuid = 'd9428888-122b-11e1-b85c-61cd3cbb3210';
+const v4Uuid = '109156be-c4fb-41ea-b1b4-efe1671c5836';
+
+uuidValidateV4(v4Uuid); // RESULT
+uuidValidateV4(v1Uuid); // RESULT
+```
+
 ### uuid.version(str)
 
 Detect RFC version of a UUID


### PR DESCRIPTION
<!--
Thank you for your contribution!

If your pull request contains considerable changes please run the benchmark before and after your
changes and include the results in the pull request description. To run the benchmark execute:

    npm run test:benchmark

from the root of this repository.
-->
Created in lieu of specific per-version validation methods as seen in https://github.com/uuidjs/uuid/pull/542

Might be something stupid I'm doing but for some reason, having the two aliased imports caused `SyntaxError: Cannot use import statement outside a module`
