### PR TITLE
Change default export to named function

### DIFF
--- a/src/v35.js
+++ b/src/v35.js
@@ -16,7 +16,7 @@ function stringToBytes(str) {
 export const DNS = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
 export const URL = '6ba7b811-9dad-11d1-80b4-00c04fd430c8';
 
-export default function (name, version, hashfunc) {
+function v35(name, version, hashfunc) {
   function generateUUID(value, namespace, buf, offset) {
     if (typeof value === 'string') {
       value = stringToBytes(value);
@@ -66,3 +66,5 @@ export default function (name, version, hashfunc) {
 
   return generateUUID;
 }
+
+export default v35;

--- a/src/v35.js
+++ b/src/v35.js
@@ -16,7 +16,7 @@ function stringToBytes(str) {
 export const DNS = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
 export const URL = '6ba7b811-9dad-11d1-80b4-00c04fd430c8';
 
-function v35(name, version, hashfunc) {
+export default function v35(name, version, hashfunc) {
   function generateUUID(value, namespace, buf, offset) {
     if (typeof value === 'string') {
       value = stringToBytes(value);
@@ -66,5 +66,3 @@ function v35(name, version, hashfunc) {
 
   return generateUUID;
 }
-
-export default v35;


### PR DESCRIPTION
Frameworks like Next.js complain about anonymous export default functions, e.g.

`Anonymous function declarations cause Fast Refresh to not preserve local component state.`

Versions beside 3.5 already use named exports, so update 3.5 to do the same.
