### PR TITLE
docs: add command 'npx' for CLI usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,14 +337,14 @@ uuidVersion('6ec0bd7f-11c0-43da-975e-2a8ad9ebae0b'); // ⇨ 4
 UUIDs can be generated from the command line using `uuid`.
 
 ```shell
-$ uuid
+$ npx uuid
 ddeb27fb-d9a0-4624-be4d-4615062daed4
 ```
 
 The default is to generate version 4 UUIDS, however the other versions are supported. Type `uuid --help` for details:
 
 ```shell
-$ uuid --help
+$ npx uuid --help
 
 Usage:
   uuid

--- a/README_js.md
+++ b/README_js.md
@@ -343,14 +343,14 @@ uuidVersion('6ec0bd7f-11c0-43da-975e-2a8ad9ebae0b'); // RESULT
 UUIDs can be generated from the command line using `uuid`.
 
 ```shell
-$ uuid
+$ npx uuid
 ddeb27fb-d9a0-4624-be4d-4615062daed4
 ```
 
 The default is to generate version 4 UUIDS, however the other versions are supported. Type `uuid --help` for details:
 
 ```shell
-$ uuid --help
+$ npx uuid --help
 
 Usage:
   uuid


### PR DESCRIPTION
It's very convenient and wonderful to be able to use uuid generation on the command line!
I think that it is convenient to use in npx.

### Before
```
$ uuid
ddeb27fb-d9a0-4624-be4d-4615062daed4
```

### After
```
$ npx uuid
ddeb27fb-d9a0-4624-be4d-4615062daed4
```