### PR TITLE
fix: require('uuid').v4 failing when used with very early versions of nodejs

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -12,7 +12,7 @@ rm -rf "$DIR"
 mkdir -p "$DIR"
 
 # Transpile CommonJS versions of files
-babel --env-name commonjs src --source-root src --out-dir "$DIR" --copy-files --quiet
+babel --env-name commonjs src --source-root src --out-dir "$DIR" --copy-files --quiet --presets=@babel/env
 
 # Transpile ESM versions of files for the browser
 babel --env-name esmBrowser src --source-root src --out-dir "$DIR/esm-browser" --copy-files --quiet

--- a/src/rng.js
+++ b/src/rng.js
@@ -1,11 +1,34 @@
 import crypto from 'crypto';
 
-const rnds8Pool = new Uint8Array(256); // # of random values to pre-allocate
+const poolSize = 256; // # of random values to pre-allocate
+const poolResetLimit = poolSize - 16; // At what point should the pool get reset
+const rnds8Pool = new Uint8Array(poolSize);
 let poolPtr = rnds8Pool.length;
 
-export default function rng() {
-  if (poolPtr > rnds8Pool.length - 16) {
+// Helper function to fill the pool with random bytes
+let resetPool;
+if (crypto.randomFillSync) {
+  resetPool = function () {
     crypto.randomFillSync(rnds8Pool);
+  };
+} else if (Buffer.from) {
+  // Node versions before 6 do not support randomFillSync, so fall back to `randomBytes` + `copy`.
+  resetPool = function () {
+    crypto.randomBytes(poolSize).copy(rnds8Pool, 0, 0, poolSize);
+  };
+} else {
+  // Node versions before 4 do not support copying from buffers into typed arrays, so it must be done in a for loop
+  resetPool = function () {
+    const randomData = crypto.randomBytes(poolSize);
+    for (let i = 0; i < poolSize; i++) {
+      rnds8Pool[i] = randomData[i];
+    }
+  };
+}
+
+export default function rng() {
+  if (poolPtr > poolResetLimit) {
+    resetPool();
     poolPtr = 0;
   }
   return rnds8Pool.slice(poolPtr, (poolPtr += 16));


### PR DESCRIPTION
Changes the babel config such that the commonjs dist files generated by the build are compatible with older versions of nodejs, and extends rng so that it works with all versions of node.

The existing code fails to run when executing in early versions of  nodejs. This in turn means some libs that still support ancient versions of node cannot consume never version of the `uuid` lib. This in turn means they are pulling in an older version which uses `Math.random()` which is a security concern.

This PR makes stringify, parse, v1, and v4 work for all versions of node.