### PR TITLE
README.md: HTTP => HTTPS

### DIFF
--- a/README_js.md
+++ b/README_js.md
@@ -16,7 +16,7 @@ require('crypto').randomFillSync = function (a) {
 
 # uuid [![CI](https://github.com/uuidjs/uuid/workflows/CI/badge.svg)](https://github.com/uuidjs/uuid/actions?query=workflow%3ACI) [![Browser](https://github.com/uuidjs/uuid/workflows/Browser/badge.svg)](https://github.com/uuidjs/uuid/actions?query=workflow%3ABrowser)
 
-For the creation of [RFC4122](http://www.ietf.org/rfc/rfc4122.txt) UUIDs
+For the creation of [RFC4122](https://www.ietf.org/rfc/rfc4122.txt) UUIDs
 
 - **Complete** - Support for RFC4122 version 1, 3, 4, and 5 UUIDs
 - **Cross-platform** - Support for ...


### PR DESCRIPTION
<!--
Thank you for your contribution!

If your pull request contains considerable changes please run the benchmark before and after your
changes and include the results in the pull request description. To run the benchmark execute:

    npm run test:benchmark

from the root of this repository.
-->

Checked the link, skipping the redirect HTTP => HTTPS this way 0:-)

<http://gh.peabody.io/uuidv6/> remains HTTP-only unfortunately…