### PR TITLE
chore: optimize uuid.v4 by 4.3x (430%) (internal stringify by 33x)

### DIFF
--- a/src/stringify.js
+++ b/src/stringify.js
@@ -10,10 +10,10 @@ for (let i = 0; i < 256; ++i) {
   byteToHex.push((i + 0x100).toString(16).substr(1));
 }
 
-function stringify(arr, offset = 0) {
+export function unsafeStringify(arr, offset = 0) {
   // Note: Be careful editing this code!  It's been tuned for performance
   // and works in ways you may not expect. See https://github.com/uuidjs/uuid/pull/434
-  const uuid = (
+  return (
     byteToHex[arr[offset + 0]] +
     byteToHex[arr[offset + 1]] +
     byteToHex[arr[offset + 2]] +
@@ -35,7 +35,10 @@ function stringify(arr, offset = 0) {
     byteToHex[arr[offset + 14]] +
     byteToHex[arr[offset + 15]]
   ).toLowerCase();
+}
 
+function stringify(arr, offset = 0) {
+  const uuid = unsafeStringify(arr, offset);
   // Consistency check for valid UUID.  If this throws, it's likely due to one
   // of the following:
   // - One or more input array values don't map to a hex octet (leading to

--- a/src/v1.js
+++ b/src/v1.js
@@ -1,5 +1,5 @@
 import rng from './rng.js';
-import stringify from './stringify.js';
+import { unsafeStringify } from './stringify.js';
 
 // **`v1()` - Generate time-based UUID**
 //
@@ -109,7 +109,7 @@ function v1(options, buf, offset) {
     b[i + n] = node[n];
   }
 
-  return buf || stringify(b);
+  return buf || unsafeStringify(b);
 }
 
 export default v1;

--- a/src/v35.js
+++ b/src/v35.js
@@ -1,4 +1,4 @@
-import stringify from './stringify.js';
+import { unsafeStringify } from './stringify.js';
 import parse from './parse.js';
 
 function stringToBytes(str) {
@@ -51,7 +51,7 @@ export default function v35(name, version, hashfunc) {
       return buf;
     }
 
-    return stringify(bytes);
+    return unsafeStringify(bytes);
   }
 
   // Function#name is not settable on some platforms (#270)

--- a/src/v4.js
+++ b/src/v4.js
@@ -1,5 +1,5 @@
 import rng from './rng.js';
-import stringify from './stringify.js';
+import { unsafeStringify } from './stringify.js';
 
 function v4(options, buf, offset) {
   options = options || {};
@@ -21,7 +21,7 @@ function v4(options, buf, offset) {
     return buf;
   }
 
-  return stringify(rnds);
+  return unsafeStringify(rnds);
 }
 
 export default v4;

--- a/test/unit/stringify.test.js
+++ b/test/unit/stringify.test.js
@@ -1,40 +1,48 @@
 import assert from 'assert';
-import stringify from '../../src/stringify.js';
+import stringify, { unsafeStringify } from '../../src/stringify.js';
 
 const BYTES = [
   0x0f, 0x5a, 0xbc, 0xd1, 0xc1, 0x94, 0x47, 0xf3, 0x90, 0x5b, 0x2d, 0xf7, 0x26, 0x3a, 0x08, 0x4b,
 ];
 
-describe('stringify', () => {
-  test('Stringify Array', () => {
-    assert.equal(stringify(BYTES), '0f5abcd1-c194-47f3-905b-2df7263a084b');
+describe('unsafeStringify', () => {
+  describe('default', () => {
+    test('Stringify Array', () => {
+      assert.equal(unsafeStringify(BYTES), '0f5abcd1-c194-47f3-905b-2df7263a084b');
+    });
+
+    test('Stringify TypedArray', () => {
+      assert.equal(unsafeStringify(Uint8Array.from(BYTES)), '0f5abcd1-c194-47f3-905b-2df7263a084b');
+      assert.equal(unsafeStringify(Int32Array.from(BYTES)), '0f5abcd1-c194-47f3-905b-2df7263a084b');
+    });
+
+    test('Stringify w/ offset', () => {
+      assert.equal(unsafeStringify([0, 0, 0, ...BYTES], 3), '0f5abcd1-c194-47f3-905b-2df7263a084b');
+    });
   });
 
-  test('Stringify TypedArray', () => {
-    assert.equal(stringify(Uint8Array.from(BYTES)), '0f5abcd1-c194-47f3-905b-2df7263a084b');
-    assert.equal(stringify(Int32Array.from(BYTES)), '0f5abcd1-c194-47f3-905b-2df7263a084b');
-  });
+  describe('safe', () => {
+    test('Stringify Array', () => {
+      assert.equal(stringify(BYTES), '0f5abcd1-c194-47f3-905b-2df7263a084b');
+    });
 
-  test('Stringify w/ offset', () => {
-    assert.equal(stringify([0, 0, 0, ...BYTES], 3), '0f5abcd1-c194-47f3-905b-2df7263a084b');
-  });
+    test('Throws on not enough values', () => {
+      const bytes = [...BYTES];
+      bytes.length = 15;
+      assert.throws(() => stringify(bytes));
+    });
 
-  test('Throws on not enough values', () => {
-    const bytes = [...BYTES];
-    bytes.length = 15;
-    assert.throws(() => stringify(bytes));
-  });
+    test('Throws on undefined value', () => {
+      const bytes = [...BYTES];
+      delete bytes[3];
+      bytes.length = 15;
+      assert.throws(() => stringify(bytes));
+    });
 
-  test('Throws on undefined value', () => {
-    const bytes = [...BYTES];
-    delete bytes[3];
-    bytes.length = 15;
-    assert.throws(() => stringify(bytes));
-  });
-
-  test('Throws on invalid value', () => {
-    const bytes = [...BYTES];
-    bytes[3] = 256;
-    assert.throws(() => stringify(bytes));
+    test('Throws on invalid value', () => {
+      const bytes = [...BYTES];
+      bytes[3] = 256;
+      assert.throws(() => stringify(bytes));
+    });
   });
 });


### PR DESCRIPTION
It turns out that validation in `uuidStringify()` is slowing it down by 33x. Since  `uuidv1()` and `uuidv4()` produce valid buffers by the virtue of their algorithm they can safely use a validation-free version of stringify.

## Benchmark changes
`uuidv1()` - faster by **1.3x**
`uuidv4()` - faster by **4.3x**
the gains are due to `.unsafeStringify()` with no validation (as it is not required) is 33x faster than the version with validation.

The public `uuidStringify()` has been left unchanged but my recommendation would be to also remove validation from this method in the future and just export the unsafe version.

## Benchmark (Core i9-10900K)
```
uuidStringify() x 2,957,961 ops/sec ±0.78% (86 runs sampled)
uuidParse() x 3,331,671 ops/sec ±0.59% (93 runs sampled)
---

uuidv1() x 3,185,198 ops/sec ±0.54% (91 runs sampled)
uuidv1() fill existing array x 9,987,064 ops/sec ±0.21% (95 runs sampled)
uuidv4() x 6,610,790 ops/sec ±0.77% (94 runs sampled)
uuidv4() fill existing array x 7,085,027 ops/sec ±0.68% (96 runs sampled)
uuidv3() x 385,764 ops/sec ±1.00% (89 runs sampled)
uuidv5() x 424,133 ops/sec ±1.43% (89 runs sampled)
Fastest is uuidv1() fill existing array
```

## Benchmark prior to changes
```
Starting. Tests take ~1 minute to run ...
uuidStringify() x 2,901,140 ops/sec ±0.61% (93 runs sampled)
uuidParse() x 3,279,020 ops/sec ±0.38% (88 runs sampled)
---

uuidv1() x 2,328,848 ops/sec ±0.60% (90 runs sampled)
uuidv1() fill existing array x 9,944,353 ops/sec ±0.26% (93 runs sampled)
uuidv4() x 1,677,495 ops/sec ±0.35% (90 runs sampled)
uuidv4() fill existing array x 6,861,270 ops/sec ±0.36% (91 runs sampled)
Fastest is uuidv1() fill existing array
```