### PR TITLE
chore: fix husky v7 hooks

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx --no-install commitlint --edit $1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx --no-install lint-staged

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "examples:browser:rollup:build": "cd examples/browser-rollup && npm install && npm run build",
     "examples:node:commonjs:test": "cd examples/node-commonjs && npm install && npm test",
     "examples:node:esmodules:test": "cd examples/node-esmodules && npm install && npm test",
+    "prepare": "husky install",
     "lint": "npm run eslint:check && npm run prettier:check",
     "eslint:check": "eslint src/ test/ examples/ *.js",
     "eslint:fix": "eslint --fix src/ test/ examples/ *.js",
@@ -111,12 +112,6 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/uuidjs/uuid.git"
-  },
-  "husky": {
-    "hooks": {
-      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
-      "pre-commit": "lint-staged"
-    }
   },
   "lint-staged": {
     "*.{js,jsx,json,md}": [


### PR DESCRIPTION
<!--
Thank you for your contribution!

If your pull request contains considerable changes please run the benchmark before and after your
changes and include the results in the pull request description. To run the benchmark execute:

    npm run test:benchmark

from the root of this repository.
-->

fix broken husky hooks. (caused by https://github.com/uuidjs/uuid/pull/585 by upgrading v4 to v7)
