### PR TITLE
feat: use native crypto.randomUUID when available

### DIFF
--- a/bundlewatch.config.json
+++ b/bundlewatch.config.json
@@ -5,9 +5,9 @@
     { "path": "./examples/browser-rollup/dist/v4-size.js", "maxSize": "0.7 kB" },
     { "path": "./examples/browser-rollup/dist/v5-size.js", "maxSize": "1.5 kB" },
 
-    { "path": "./examples/browser-webpack/dist/v1-size.js", "maxSize": "1.3 kB" },
-    { "path": "./examples/browser-webpack/dist/v3-size.js", "maxSize": "2.5 kB" },
-    { "path": "./examples/browser-webpack/dist/v4-size.js", "maxSize": "1.0 kB" },
-    { "path": "./examples/browser-webpack/dist/v5-size.js", "maxSize": "1.9 kB" }
+    { "path": "./examples/browser-webpack/dist/v1-size.js", "maxSize": "1.0 kB" },
+    { "path": "./examples/browser-webpack/dist/v3-size.js", "maxSize": "2.1 kB" },
+    { "path": "./examples/browser-webpack/dist/v4-size.js", "maxSize": "0.7 kB" },
+    { "path": "./examples/browser-webpack/dist/v5-size.js", "maxSize": "1.5 kB" }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "module": "./dist/esm-node/index.js",
   "browser": {
     "./dist/md5.js": "./dist/md5-browser.js",
+    "./dist/native.js": "./dist/native-browser.js",
     "./dist/rng.js": "./dist/rng-browser.js",
     "./dist/sha1.js": "./dist/sha1-browser.js",
     "./dist/esm-node/index.js": "./dist/esm-browser/index.js"

--- a/src/native-browser.js
+++ b/src/native-browser.js
@@ -1,0 +1,4 @@
+const randomUUID =
+  typeof crypto !== 'undefined' && crypto.randomUUID && crypto.randomUUID.bind(crypto);
+
+export default { randomUUID };

--- a/src/native.js
+++ b/src/native.js
@@ -1,0 +1,3 @@
+import crypto from 'crypto';
+
+export default { randomUUID: crypto.randomUUID };

--- a/src/v4.js
+++ b/src/v4.js
@@ -3,11 +3,11 @@ import rng from './rng.js';
 import stringify from './stringify.js';
 
 function v4(options, buf, offset) {
-  options = options || {};
-
-  if (native.randomUUID && buf == null && options.random == null && options.rng == null) {
+  if (native.randomUUID && !buf && !options) {
     return native.randomUUID();
   }
+
+  options = options || {};
 
   const rnds = options.random || (options.rng || rng)();
 

--- a/src/v4.js
+++ b/src/v4.js
@@ -1,8 +1,13 @@
+import native from './native.js';
 import rng from './rng.js';
 import stringify from './stringify.js';
 
 function v4(options, buf, offset) {
   options = options || {};
+
+  if (native.randomUUID && buf == null && options.random == null && options.rng == null) {
+    return native.randomUUID();
+  }
 
   const rnds = options.random || (options.rng || rng)();
 

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -34,6 +34,14 @@ const capabilities = [
   },
 
   // Chrome
+  // Chrome 92 introduced native support for crypto.randomUUID
+  {
+    ...commonCapabilities,
+    browserName: 'Chrome',
+    browser_version: '92.0',
+    os: 'Windows',
+    os_version: '10',
+  },
   {
     ...commonCapabilities,
     browserName: 'Chrome',
@@ -41,6 +49,7 @@ const capabilities = [
     os: 'Windows',
     os_version: '10',
   },
+  // Chrome 49 released on 2016-03-02 was the last version supported on Windows XP, Windows Vista, Mac OS X 10.6, 10.7, and 10.8
   {
     ...commonCapabilities,
     browserName: 'Chrome',


### PR DESCRIPTION
*Before:*

```
uuidv4() x 2,232,325 ops/sec ±0.12% (95 runs sampled)
uuidv4() fill existing array x 8,398,262 ops/sec ±0.16% (97 runs sampled)
```

*After:*

```text
uuidv4() x 25,076,827 ops/sec ±1.93% (96 runs sampled)
uuidv4() fill existing array x 8,407,653 ops/sec ±0.21% (97 runs sampled)
```

This uses the native `crypto.randomUUID` if available, which results in more than an **11x** speedup on Node.js v16.11.1 on my M1 MacBook Air. All this while only increasing the bundle size with **34 bytes**!

<img width="710" alt="Screenshot 2021-11-30 at 09 46 51" src="https://user-images.githubusercontent.com/189580/144014610-f885cb84-7320-4fd8-b2ef-30155e3c5a22.png">


The patch implements my changes described here: https://github.com/uuidjs/uuid/pull/555#issuecomment-770720130

Closes #555 