### PR TITLE
Support only node 10

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -3,13 +3,13 @@
   "plugins": [],
   "env": {
     "commonjs": {
-      "presets": [["@babel/preset-env", { "targets": { "node": "8" }, "modules": "commonjs" }]]
+      "presets": [["@babel/preset-env", { "targets": { "node": "10" }, "modules": "commonjs" }]]
     },
     "esmBrowser": {
       "presets": [["@babel/preset-env", { "modules": false }]]
     },
     "esmNode": {
-      "presets": [["@babel/preset-env", { "targets": { "node": "8" }, "modules": false }]]
+      "presets": [["@babel/preset-env", { "targets": { "node": "10" }, "modules": false }]]
     }
   }
 }


### PR DESCRIPTION
This change is a noop with respect to the build, it yields the exact same output files (tested by building with and without this patch and running `diff -r dist-node-8 dist-node-10` which yields an empty result).