### PR TITLE
Drop IE 11 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ For the creation of [RFC4122](https://www.ietf.org/rfc/rfc4122.txt) UUIDs
 - **Cross-platform** - Support for ...
   - CommonJS, [ECMAScript Modules](#ecmascript-modules) and [CDN builds](#cdn-builds)
   - Node 10, 12, 14, 16
-  - Chrome, Safari, Firefox, Edge, IE 11 browsers
+  - Chrome, Safari, Firefox, Edge browsers
   - Webpack and rollup.js module bundlers
   - [React Native / Expo](#react-native--expo)
 - **Secure** - Cryptographically-strong random values
@@ -416,6 +416,10 @@ Note: If you are using Expo, you must be using at least `react-native-get-random
 ### Web Workers / Service Workers (Edge <= 18)
 
 [In Edge <= 18, Web Crypto is not supported in Web Workers or Service Workers](https://caniuse.com/#feat=cryptography) and we are not aware of a polyfill (let us know if you find one, please).
+
+### IE 11 (Internet Explorer)
+
+Support for IE11 and other legacy browsers has been dropped as of `uuid@9`. If you need to support legacy browsers, you can always transpile the uuid module source yourself (e.g. using [Babel](https://babeljs.io/)).
 
 ## Upgrading From `uuid@7`
 

--- a/README_js.md
+++ b/README_js.md
@@ -25,7 +25,7 @@ For the creation of [RFC4122](https://www.ietf.org/rfc/rfc4122.txt) UUIDs
 - **Cross-platform** - Support for ...
   - CommonJS, [ECMAScript Modules](#ecmascript-modules) and [CDN builds](#cdn-builds)
   - Node 10, 12, 14, 16
-  - Chrome, Safari, Firefox, Edge, IE 11 browsers
+  - Chrome, Safari, Firefox, Edge browsers
   - Webpack and rollup.js module bundlers
   - [React Native / Expo](#react-native--expo)
 - **Secure** - Cryptographically-strong random values
@@ -425,6 +425,10 @@ Note: If you are using Expo, you must be using at least `react-native-get-random
 ### Web Workers / Service Workers (Edge <= 18)
 
 [In Edge <= 18, Web Crypto is not supported in Web Workers or Service Workers](https://caniuse.com/#feat=cryptography) and we are not aware of a polyfill (let us know if you find one, please).
+
+### IE 11 (Internet Explorer)
+
+Support for IE11 and other legacy browsers has been dropped as of `uuid@9`. If you need to support legacy browsers, you can always transpile the uuid module source yourself (e.g. using [Babel](https://babeljs.io/)).
 
 ## Upgrading From `uuid@7`
 

--- a/babel.config.json
+++ b/babel.config.json
@@ -3,16 +3,64 @@
   "plugins": [],
   "env": {
     "commonjsNode": {
-      "presets": [["@babel/preset-env", { "targets": { "node": "10" }, "modules": "commonjs" }]]
+      "presets": [
+        [
+          "@babel/preset-env",
+          {
+            "targets": {
+              "node": "10"
+            },
+            "modules": "commonjs"
+          }
+        ]
+      ]
     },
     "esmNode": {
-      "presets": [["@babel/preset-env", { "targets": { "node": "10" }, "modules": false }]]
+      "presets": [
+        [
+          "@babel/preset-env",
+          {
+            "targets": {
+              "node": "10"
+            },
+            "modules": false
+          }
+        ]
+      ]
     },
     "commonjsBrowser": {
-      "presets": [["@babel/preset-env", { "modules": "commonjs" }]]
+      "presets": [
+        [
+          "@babel/preset-env",
+          {
+            "targets": {
+              "chrome": "49",
+              "edge": "15",
+              "firefox": "53",
+              "safari": "11"
+            },
+            "bugfixes": true,
+            "modules": "commonjs"
+          }
+        ]
+      ]
     },
     "esmBrowser": {
-      "presets": [["@babel/preset-env", { "modules": false }]]
+      "presets": [
+        [
+          "@babel/preset-env",
+          {
+            "targets": {
+              "chrome": "49",
+              "edge": "15",
+              "firefox": "53",
+              "safari": "11"
+            },
+            "bugfixes": true,
+            "modules": false
+          }
+        ]
+      ]
     }
   }
 }

--- a/src/rng-browser.js
+++ b/src/rng-browser.js
@@ -9,15 +9,11 @@ const rnds8 = new Uint8Array(16);
 export default function rng() {
   // lazy load so that environments that need to polyfill have a chance to do so
   if (!getRandomValues) {
-    // getRandomValues needs to be invoked in a context where "this" is a Crypto implementation. Also,
-    // find the complete implementation of crypto (msCrypto) on IE11.
+    // getRandomValues needs to be invoked in a context where "this" is a Crypto implementation.
     getRandomValues =
-      (typeof crypto !== 'undefined' &&
-        crypto.getRandomValues &&
-        crypto.getRandomValues.bind(crypto)) ||
-      (typeof msCrypto !== 'undefined' &&
-        typeof msCrypto.getRandomValues === 'function' &&
-        msCrypto.getRandomValues.bind(msCrypto));
+      typeof crypto !== 'undefined' &&
+      crypto.getRandomValues &&
+      crypto.getRandomValues.bind(crypto);
     if (!getRandomValues) {
       throw new Error(
         'crypto.getRandomValues() not supported. See https://github.com/uuidjs/uuid#getrandomvalues-not-supported'

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -14,45 +14,26 @@ const commonCapabilities = {
 };
 
 const capabilities = [
-  // IE
-  {
-    'bstack:options': {
-      os: 'Windows',
-      osVersion: '10',
-      ...commonCapabilities,
-    },
-    browserName: 'IE',
-    browserVersion: '11.0',
-  },
-  {
-    'bstack:options': {
-      ...commonCapabilities,
-      os: 'Windows',
-      osVersion: '7',
-    },
-    browserName: 'IE',
-    browserVersion: '11.0',
-  },
-
   // Chrome
+  // Latest
+  {
+    'bstack:options': {
+      ...commonCapabilities,
+      os: 'Windows',
+      osVersion: '11',
+    },
+    browserName: 'Chrome',
+    browserVersion: '103.0',
+  },
   // Chrome 92 introduced native support for crypto.randomUUID
   {
     'bstack:options': {
       ...commonCapabilities,
       os: 'Windows',
-      osVersion: '10',
+      osVersion: '11',
     },
     browserName: 'Chrome',
     browserVersion: '92.0',
-  },
-  {
-    'bstack:options': {
-      ...commonCapabilities,
-      os: 'Windows',
-      osVersion: '10',
-    },
-    browserName: 'Chrome',
-    browserVersion: '81.0',
   },
   // Chrome 49 released on 2016-03-02 was the last version supported on Windows XP, Windows Vista, Mac OS X 10.6, 10.7, and 10.8
   {
@@ -66,15 +47,17 @@ const capabilities = [
   },
 
   // Firefox
+  // Latest
   {
     'bstack:options': {
       ...commonCapabilities,
       os: 'Windows',
-      osVersion: '10',
+      osVersion: '11',
     },
     browserName: 'Firefox',
-    browserVersion: '75.0',
+    browserVersion: '103.0',
   },
+  // Firefox 51 was the first Firefox to correctly support const/let
   {
     'bstack:options': {
       ...commonCapabilities,
@@ -82,7 +65,7 @@ const capabilities = [
       osVersion: '10',
     },
     browserName: 'Firefox',
-    browserVersion: '44.0',
+    browserVersion: '51.0',
   },
 
   // Edge
@@ -90,11 +73,13 @@ const capabilities = [
     'bstack:options': {
       ...commonCapabilities,
       os: 'Windows',
-      osVersion: '10',
+      osVersion: '11',
     },
     browserName: 'Edge',
-    browserVersion: '81.0',
+    browserVersion: '103.0',
   },
+  // While Edge 12 already supported const/let, Edge 15 is the earliest Edge available on
+  // Browserstack
   {
     'bstack:options': {
       ...commonCapabilities,
@@ -110,19 +95,20 @@ const capabilities = [
     'bstack:options': {
       ...commonCapabilities,
       os: 'OS X',
-      osVersion: 'Catalina',
+      osVersion: 'Monterey',
     },
     browserName: 'Safari',
-    browserVersion: '13.0',
+    browserVersion: '15.0',
   },
+  // Safari 11 was the first Safari to correctly support const/let
   {
     'bstack:options': {
       ...commonCapabilities,
       os: 'OS X',
-      osVersion: 'Sierra',
+      osVersion: 'High Sierra',
     },
     browserName: 'Safari',
-    browserVersion: '10.0',
+    browserVersion: '11.0',
   },
 ];
 


### PR DESCRIPTION
Closes #469

After adjusting the babel preset-env targets the browser build only changed with respect to `let/const` vs. `var` usage, see [this diff](https://gist.github.com/ctavan/519360f8777905838a9398b534e530ad#file-browser-build-diff).

It all still works in IE11 🤷‍♂️ .

I could break IE11 support by removing the `msCrypto` special case in: https://github.com/uuidjs/uuid/blob/c9e076c852edad7e9a06baaa1d148cf4eda6c6c4/src/rng-browser.js#L18-L20

On the other hand those 3 lines don't really hurt…

So the question is now whether we want to be even more aggressive with respect to browser support?

The next step we could go would be to allow function default parameters (equivalent to moving `firefox 51 -> 53` and `edge 14 -> 15`), which would add [this diff](https://gist.github.com/ctavan/519360f8777905838a9398b534e530ad#file-diff-ff53-edge-15-diff).

After that, the browser code would be an untranspiled copy of what we currently have in `src/`.

So I guess this all depends on how much "modern" syntax we're planning to use in the future and what general browser support matrix we're planning for?

Looking forward to hearing your thoughts!