### PR TITLE
build!: add `engines` to package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ For the creation of [RFC4122](https://www.ietf.org/rfc/rfc4122.txt) UUIDs
 - **Complete** - Support for RFC4122 version 1, 3, 4, and 5 UUIDs
 - **Cross-platform** - Support for ...
   - CommonJS, [ECMAScript Modules](#ecmascript-modules) and [CDN builds](#cdn-builds)
-  - Node 10, 12, 14, 16
+  - Node 10+ (LTS releases)
   - Chrome, Safari, Firefox, Edge, IE 11 browsers
   - Webpack and rollup.js module bundlers
   - [React Native / Expo](#react-native--expo)

--- a/README_js.md
+++ b/README_js.md
@@ -24,7 +24,7 @@ For the creation of [RFC4122](https://www.ietf.org/rfc/rfc4122.txt) UUIDs
 - **Complete** - Support for RFC4122 version 1, 3, 4, and 5 UUIDs
 - **Cross-platform** - Support for ...
   - CommonJS, [ECMAScript Modules](#ecmascript-modules) and [CDN builds](#cdn-builds)
-  - Node 10, 12, 14, 16
+  - Node 10+ (LTS releases)
   - Chrome, Safari, Firefox, Edge, IE 11 browsers
   - Webpack and rollup.js module bundlers
   - [React Native / Expo](#react-native--expo)

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "rfc4122"
   ],
   "license": "MIT",
+  "engines": {
+    "node": "10 - 16"
+  },
   "bin": {
     "uuid": "./dist/bin/uuid"
   },


### PR DESCRIPTION
While having [this discussion](https://github.com/semver/semver/issues/716), and in light of the recent question about whether or not to make this next release a major version bump, I noticed we don't have an `engines` field in package.json.  Adding this will allow installers to enforce our stated platform support requirements.  Specifically:

* `npm` will **warn** when installing in unsupported node environments
* `yarn` will **error** when installing in unsupported node environments (!!!)

In other words, this makes our decision to drop node 8 more explicit and, for node 8 users, a bit more painful.

Note:  I've changed the README phrasing for node support to be "future-compatible", allowing for node@10+ rather than just 10-16, while keeping the caveat that we only really support LTS releases. 

**Implications for future platform support changes:**  The discussion I link to above about how platform support should be represented in a version string is interesting.   There is some merit to the argument that platform support should be enforced with tooling, and not via SemVer.   E.g. When we drop `node@10` support, we could arguably do that as a patch release, and rely on installers to surface the issue for dependent projects.  However this doesn't solve the problem for other types of platform dependencies.  E.g. if we decided to drop.. I dunno... Electron support (not that we have it now), that would probably still need to be a semver-major bump.

Something to think about.

**Related**: 'Found this [nice little semver playground](https://semver.npmjs.com/)