### PR TITLE
Mark `./dist/esm-browser/*.js`  as ESM modules

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -16,6 +16,7 @@ babel --env-name commonjs src --source-root src --out-dir "$DIR" --copy-files --
 
 # Transpile ESM versions of files for the browser
 babel --env-name esmBrowser src --source-root src --out-dir "$DIR/esm-browser" --copy-files --quiet
+echo "{ \"type\": \"module\" }" > "$DIR/esm-browser/package.json"
 
 # Transpile ESM versions of files for node
 babel --env-name esmNode src --source-root src --out-dir "$DIR/esm-node" --copy-files --quiet


### PR DESCRIPTION
See [packagejson-and-file-extensions](https://nodejs.org/api/packages.html#packagejson-and-file-extensions). This trick was also used by rollup distribution.

<!--
Thank you for your contribution!

If your pull request contains considerable changes please run the benchmark before and after your
changes and include the results in the pull request description. To run the benchmark execute:

    npm run test:benchmark

from the root of this repository.
-->
