### PR TITLE
Fix import versions direclty uuid

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,13 @@
       },
       "default": "./dist/esm-browser/index.js"
     },
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./v1": "./dist/v1.js",
+    "./v2": "./dist/v2.js",
+    "./v3": "./dist/v3.js",
+    "./v4": "./dist/v4.js",
+    "./v5": "./dist/v5.js",
+    "./v35": "./dist/v35.js"
   },
   "module": "./dist/esm-node/index.js",
   "browser": {


### PR DESCRIPTION
<!--
Thank you for your contribution!

If your pull request contains considerable changes please run the benchmark before and after your
changes and include the results in the pull request description. To run the benchmark execute:

    npm run test:benchmark

from the root of this repository.
-->

**Hubspot** uses **request**
**request** uses **uuid**

Which causes the following issue
<img width="646" alt="Screen Shot 2022-01-17 at 21 28 04" src="https://user-images.githubusercontent.com/13334788/149814650-6006993f-eb40-44c2-b726-77f89a3694bc.png">


