### PR TITLE
fix: importing through mjs in webpack@4

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "uuid": "./dist/bin/uuid"
   },
   "sideEffects": false,
-  "main": "./dist/index.js",
+  "main": "./dist/index",
   "exports": {
     ".": {
       "node": {
@@ -39,7 +39,8 @@
     "./dist/native.js": "./dist/native-browser.js",
     "./dist/rng.js": "./dist/rng-browser.js",
     "./dist/sha1.js": "./dist/sha1-browser.js",
-    "./dist/esm-node/index.js": "./dist/esm-browser/index.js"
+    "./dist/esm-node/index.js": "./dist/esm-browser/index.js",
+    "./dist/index.mjs": "./dist/esm-browser/index.js"
   },
   "files": [
     "CHANGELOG.md",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -38,6 +38,8 @@ babel --env-name esmBrowser src --source-root src --out-dir "$DIR/esm-browser" -
 # Transpile ESM versions of files for node
 babel --env-name esmNode src --source-root src --out-dir "$DIR/esm-node" --copy-files --quiet
 
+echo "export * from './esm-node';" > "$DIR/index.mjs"
+
 # No need to have the CLI files in the esm build
 rm -rf "$DIR/commonjs-browser/bin"
 rm -rf "$DIR/commonjs-browser/uuid-bin.js"


### PR DESCRIPTION
I have trouble importing this package in an `mjs` file in a project created using create-react-app@4.0.3.

Here is a reproduction: https://github.com/davidyuk/reproductions/tree/react-uuid

You need to run `yarn && yarn build` the see the error:
```
Failed to compile.

./src/test.mjs
Can't import the named export 'v4' from non EcmaScript module (only default export is available)
```

create-react-app@4.0.3 uses webpack@4 that resolves dependencies differently if `mjs` files are involved. It is fixable by enabling `javascript/auto` for `mjs`, but create-react-app doesn't allow to change configuration without ejecting. So, I'm proposing to apply a fix that makes it works, it is based on https://github.com/webpack/webpack/issues/7482#issuecomment-394838925.