### PR TITLE
fix: add `browser` condition to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
       },
       "browser": {
         "import": "./dist/esm-browser/index.js",
-        "require": "./dist/index.js",
-        "default": "./dist/esm-browser/index.js"
+        "require": "./dist/index.js"
       },
       "default": "./dist/esm-browser/index.js"
     },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "require": "./dist/index.js",
         "import": "./wrapper.mjs"
       },
-      "browser": {,
+      "browser": {
         "import": "./dist/esm-browser/index.js",
         "require": "./dist/index.js",
         "default": "./dist/esm-browser/index.js"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
         "require": "./dist/index.js",
         "import": "./wrapper.mjs"
       },
-      "browser": {
+      "browser": {,
+        "import": "./dist/esm-browser/index.js",
         "require": "./dist/index.js",
         "default": "./dist/esm-browser/index.js"
       },

--- a/package.json
+++ b/package.json
@@ -25,6 +25,10 @@
         "require": "./dist/index.js",
         "import": "./wrapper.mjs"
       },
+      "browser": {
+        "require": "./dist/index.js",
+        "default": "./dist/esm-browser/index.js"
+      },
       "default": "./dist/esm-browser/index.js"
     },
     "./package.json": "./package.json"


### PR DESCRIPTION
`jest@28` will ship with `exports` support. But when using `jest-environment-jsdom` to simulate a browser environment, we don't provide the `node` condition, meaning it resolves to `default`. Unless ESM is enabled, this results in a syntax error.