### PR TITLE
chore: run node-esmodule package.json test only in latest node LTS

### DIFF
--- a/examples/node-esmodules/example.mjs
+++ b/examples/node-esmodules/example.mjs
@@ -10,7 +10,7 @@ import {
   version as uuidVersion,
 } from 'uuid';
 import * as uuid from 'uuid';
-import pkg from 'uuid/package.json';
+import pkg from 'uuid/package.json' assert {type: 'json'};
 
 console.log('uuidv1()', uuidv1());
 

--- a/examples/node-esmodules/example.mjs
+++ b/examples/node-esmodules/example.mjs
@@ -10,7 +10,7 @@ import {
   version as uuidVersion,
 } from 'uuid';
 import * as uuid from 'uuid';
-import pkg from 'uuid/package.json' assert {type: 'json'};
+import pkg from 'uuid/package.json' assert { type: 'json' };
 
 console.log('uuidv1()', uuidv1());
 

--- a/examples/node-esmodules/example.mjs
+++ b/examples/node-esmodules/example.mjs
@@ -10,7 +10,6 @@ import {
   version as uuidVersion,
 } from 'uuid';
 import * as uuid from 'uuid';
-import pkg from 'uuid/package.json' assert { type: 'json' };
 
 console.log('uuidv1()', uuidv1());
 
@@ -65,6 +64,3 @@ console.log('uuid.parse()', uuid.parse(MY_NAMESPACE));
 console.log('uuid.stringify()', uuid.stringify(uuid.parse(MY_NAMESPACE)));
 console.log('uuid.validate()', uuid.validate(MY_NAMESPACE));
 console.log('uuid.version()', uuid.version(MY_NAMESPACE));
-
-// Some tools like react-native need to introspect the package.json file
-console.log('pkg.name', pkg.name);

--- a/examples/node-esmodules/package.json
+++ b/examples/node-esmodules/package.json
@@ -3,7 +3,9 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "test": "( node --version | grep -vq 'v16' ) || ( node --experimental-json-modules example.mjs )"
+    "test:package": "( node --version | grep -vq 'v16' ) || ( node --experimental-json-modules package.mjs )",
+    "test:example": "node --experimental-json-modules example.mjs",
+    "test": "npm-run-all test:*"
   },
   "dependencies": {
     "uuid": "file:../../.local/uuid"

--- a/examples/node-esmodules/package.json
+++ b/examples/node-esmodules/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "test:package": "( node --version | grep -vq 'v16' ) || ( node --experimental-json-modules package.mjs )",
-    "test:example": "node --experimental-json-modules example.mjs",
+    "test:example": "node example.mjs",
     "test": "npm-run-all test:*"
   },
   "dependencies": {

--- a/examples/node-esmodules/package.json
+++ b/examples/node-esmodules/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "test": "node --experimental-modules --experimental-json-modules example.mjs"
+    "test": "( node --version | grep -vq 'v16' ) || ( node --experimental-json-modules example.mjs )"
   },
   "dependencies": {
     "uuid": "file:../../.local/uuid"

--- a/examples/node-esmodules/package.mjs
+++ b/examples/node-esmodules/package.mjs
@@ -1,0 +1,4 @@
+import pkg from 'uuid/package.json' assert { type: 'json' };
+
+// Some tools like react-native need to introspect the package.json file
+console.log('pkg.name', pkg.name);

--- a/scripts/testpack.sh
+++ b/scripts/testpack.sh
@@ -10,6 +10,7 @@ mkdir -p ../test-pack
 
 cp examples/node-commonjs/example.js ../test-pack/commonjs.js
 cp examples/node-esmodules/example.mjs ../test-pack/esmodules.mjs
+cp examples/node-esmodules/package.mjs ../test-pack/esmodules-package.mjs
 
 cd ../test-pack
 
@@ -18,8 +19,9 @@ npm init -y
 npm install ../uuid/uuid-*.tgz
 
 node commonjs.js
+node esmodules.js
 
 # Support for json esm imports requires import assertions starting in Node.js v16.14.0 which were
 # not supported in earlier versions. Therefore we restrict the ESM test to more recent versions of
 # Node.js:
-( node --version | grep -vq 'v16' ) || ( node --experimental-json-modules esmodules.mjs )
+( node --version | grep -vq 'v16' ) || ( node --experimental-json-modules esmodules-package.mjs )

--- a/scripts/testpack.sh
+++ b/scripts/testpack.sh
@@ -18,4 +18,8 @@ npm init -y
 npm install ../uuid/uuid-*.tgz
 
 node commonjs.js
-node --experimental-json-modules esmodules.mjs
+
+# Support for json esm imports requires import assertions starting in Node.js v16.14.0 which were
+# not supported in earlier versions. Therefore we restrict the ESM test to more recent versions of
+# Node.js:
+( node --version | grep -vq 'v16' ) || ( node --experimental-json-modules esmodules.mjs )

--- a/scripts/testpack.sh
+++ b/scripts/testpack.sh
@@ -19,7 +19,7 @@ npm init -y
 npm install ../uuid/uuid-*.tgz
 
 node commonjs.js
-node esmodules.js
+node esmodules.mjs
 
 # Support for json esm imports requires import assertions starting in Node.js v16.14.0 which were
 # not supported in earlier versions. Therefore we restrict the ESM test to more recent versions of


### PR DESCRIPTION
While ESM support has been stable in current versions of Node.js 14.x and 16.x, support for importing JSON files is still experimental and evolving.

Since we still want to cover the fact that the package is exporting it's package.json file, this test is now extracted to only run with the updated JSON import syntax which requires import assertions and which was introduced in Node.js 16.14.0.

Fixes #619