### PR TITLE
Fix undefined return from crypto.getRandomValues in older Safari

### DIFF
--- a/src/rng-browser.js
+++ b/src/rng-browser.js
@@ -24,6 +24,8 @@ export default function rng() {
       );
     }
   }
+  
+  getRandomValues(rnds8)
 
-  return getRandomValues(rnds8);
+  return rnds8;
 }


### PR DESCRIPTION
In some envs (like Safari 6), `crypto.getRandomValues` does not return anything and as per spec it changes its argument in place
This behavior it's specified (not clearly) in [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/getRandomValues) right at the beginning of the paragraph:
`The array given as the parameter is filled with random numbers`

The current implementation is right on the current web crypto [specs](https://w3c.github.io/webcrypto/#Crypto-method-getRandomValues) (point 4).

This version should work across all window.crypto browsers and IE (`msCrypto`)
