### PR TITLE
chore: drop node 10.x to upgrade dev dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ For the creation of [RFC4122](https://www.ietf.org/rfc/rfc4122.txt) UUIDs
 - **Complete** - Support for RFC4122 version 1, 3, 4, and 5 UUIDs
 - **Cross-platform** - Support for ...
   - CommonJS, [ECMAScript Modules](#ecmascript-modules) and [CDN builds](#cdn-builds)
-  - Node 10, 12, 14, 16
+  - Node 12, 14, 16, 18
   - Chrome, Safari, Firefox, Edge browsers
   - Webpack and rollup.js module bundlers
   - [React Native / Expo](#react-native--expo)

--- a/README_js.md
+++ b/README_js.md
@@ -24,7 +24,7 @@ For the creation of [RFC4122](https://www.ietf.org/rfc/rfc4122.txt) UUIDs
 - **Complete** - Support for RFC4122 version 1, 3, 4, and 5 UUIDs
 - **Cross-platform** - Support for ...
   - CommonJS, [ECMAScript Modules](#ecmascript-modules) and [CDN builds](#cdn-builds)
-  - Node 10, 12, 14, 16
+  - Node 12, 14, 16, 18
   - Chrome, Safari, Firefox, Edge browsers
   - Webpack and rollup.js module bundlers
   - [React Native / Expo](#react-native--expo)


### PR DESCRIPTION
BREAKING CHANGE: This library always aims at supporting one EOLed LTS release
which by this time now is 12.x which has reached EOL 30 Apr 2022.

The actual change was already introduced in #643 but the commit was missing the
breaking change label.