### PR TITLE
chore: add FUNDING.yml, fixes #384

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [broofa]

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-github: [broofa]
+github: [broofa, ctavan]

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "uuid",
   "version": "8.3.2",
   "description": "RFC4122 (v1, v4, and v5) UUIDs",
+  "funding": [
+    "https://github.com/sponsors/broofa",
+    "https://github.com/sponsors/ctavan"
+  ],
   "commitlint": {
     "extends": [
       "@commitlint/config-conventional"


### PR DESCRIPTION
Enables the "Sponsor this project" sidebar.

I honestly don't know if this will generate any actual sponsorships, but I'd like to try it out just to see what happens.  I expect this'll be more useful for the insight it brings into how [in]effective github is as a source of revenue for opensource developers than anything else.

@ctavan: 'Doesn't look like you're setup to take sponsorships on Github, but I'm happy to add you to this of course.  I'm open to suggestions for adding others, but looking at the "contributors", I think you and I are the two most obvious candidates here.