### PR TITLE
perf: removed unnecessary offset and byteToHex calc

### DIFF
--- a/src/stringify-internal.js
+++ b/src/stringify-internal.js
@@ -1,3 +1,8 @@
+/**
+ * This is the internal `stringify()` function used by the library.
+ * It isn't exposed in the index because it assumes no offset.
+ */
+
 import validate from './validate.js';
 
 /**
@@ -263,35 +268,35 @@ const byteToHex = [
   'ff',
 ];
 
-export function unsafeStringify(arr, offset = 0) {
+export function unsafeStringify(arr) {
   // Note: Be careful editing this code!  It's been tuned for performance
   // and works in ways you may not expect. See https://github.com/uuidjs/uuid/pull/434
   return (
-    byteToHex[arr[offset + 0]] +
-    byteToHex[arr[offset + 1]] +
-    byteToHex[arr[offset + 2]] +
-    byteToHex[arr[offset + 3]] +
+    byteToHex[arr[0]] +
+    byteToHex[arr[1]] +
+    byteToHex[arr[2]] +
+    byteToHex[arr[3]] +
     '-' +
-    byteToHex[arr[offset + 4]] +
-    byteToHex[arr[offset + 5]] +
+    byteToHex[arr[4]] +
+    byteToHex[arr[5]] +
     '-' +
-    byteToHex[arr[offset + 6]] +
-    byteToHex[arr[offset + 7]] +
+    byteToHex[arr[6]] +
+    byteToHex[arr[7]] +
     '-' +
-    byteToHex[arr[offset + 8]] +
-    byteToHex[arr[offset + 9]] +
+    byteToHex[arr[8]] +
+    byteToHex[arr[9]] +
     '-' +
-    byteToHex[arr[offset + 10]] +
-    byteToHex[arr[offset + 11]] +
-    byteToHex[arr[offset + 12]] +
-    byteToHex[arr[offset + 13]] +
-    byteToHex[arr[offset + 14]] +
-    byteToHex[arr[offset + 15]]
+    byteToHex[arr[10]] +
+    byteToHex[arr[11]] +
+    byteToHex[arr[12]] +
+    byteToHex[arr[13]] +
+    byteToHex[arr[14]] +
+    byteToHex[arr[15]]
   ).toLowerCase();
 }
 
-function stringify(arr, offset = 0) {
-  const uuid = unsafeStringify(arr, offset);
+function stringify(arr) {
+  const uuid = unsafeStringify(arr);
   // Consistency check for valid UUID.  If this throws, it's likely due to one
   // of the following:
   // - One or more input array values don't map to a hex octet (leading to

--- a/src/v1.js
+++ b/src/v1.js
@@ -1,5 +1,5 @@
 import rng from './rng.js';
-import { unsafeStringify } from './stringify.js';
+import { unsafeStringify } from './stringify-internal.js';
 
 // **`v1()` - Generate time-based UUID**
 //

--- a/src/v35.js
+++ b/src/v35.js
@@ -1,4 +1,4 @@
-import { unsafeStringify } from './stringify.js';
+import { unsafeStringify } from './stringify-internal.js';
 import parse from './parse.js';
 
 function stringToBytes(str) {

--- a/src/v4.js
+++ b/src/v4.js
@@ -1,6 +1,6 @@
 import native from './native.js';
 import rng from './rng.js';
-import { unsafeStringify } from './stringify.js';
+import { unsafeStringify } from './stringify-internal.js';
 
 function v4(options, buf, offset) {
   if (native.randomUUID && !buf && !options) {


### PR DESCRIPTION
Before:
```
uuid.stringify() x 1,298,884 ops/sec ±1.39% (91 runs sampled)
uuid.parse() x 1,620,813 ops/sec ±0.23% (97 runs sampled)

uuid.v1() x 885,718 ops/sec ±0.78% (96 runs sampled)
uuid.v1() fill existing array x 2,211,049 ops/sec ±0.48% (90 runs sampled)
uuid.v4() x 9,312,249 ops/sec ±2.75% (86 runs sampled)
uuid.v4() fill existing array x 2,894,864 ops/sec ±2.10% (90 runs sampled)
uuid.v3() x 151,383 ops/sec ±1.88% (75 runs sampled)
uuid.v5() x 168,435 ops/sec ±2.53% (64 runs sampled)
```

After:
```
uuid.stringify() x 1,557,441 ops/sec ±5.29% (87 runs sampled)
uuid.parse() x 1,631,789 ops/sec ±0.22% (97 runs sampled)

uuid.v1() x 1,118,442 ops/sec ±0.32% (96 runs sampled)
uuid.v1() fill existing array x 2,258,223 ops/sec ±0.44% (93 runs sampled)
uuid.v4() x 9,465,136 ops/sec ±2.26% (88 runs sampled)
uuid.v4() fill existing array x 2,986,081 ops/sec ±0.18% (96 runs sampled)
uuid.v3() x 155,015 ops/sec ±2.15% (75 runs sampled)
uuid.v5() x 171,307 ops/sec ±2.27% (77 runs sampled)
```


Results vary, yet we have less calcs to do and an internal implementation preventing a useless offset being used.