### PR TITLE
perf: unsafe stringify now uses concatenation

### DIFF
--- a/src/stringify.js
+++ b/src/stringify.js
@@ -13,28 +13,28 @@ for (let i = 0; i < 256; ++i) {
 export function unsafeStringify(arr, offset = 0) {
   // Note: Be careful editing this code!  It's been tuned for performance
   // and works in ways you may not expect. See https://github.com/uuidjs/uuid/pull/434
-  return (
-    byteToHex[arr[offset + 0]] +
-    byteToHex[arr[offset + 1]] +
-    byteToHex[arr[offset + 2]] +
-    byteToHex[arr[offset + 3]] +
-    '-' +
-    byteToHex[arr[offset + 4]] +
-    byteToHex[arr[offset + 5]] +
-    '-' +
-    byteToHex[arr[offset + 6]] +
-    byteToHex[arr[offset + 7]] +
-    '-' +
-    byteToHex[arr[offset + 8]] +
-    byteToHex[arr[offset + 9]] +
-    '-' +
-    byteToHex[arr[offset + 10]] +
-    byteToHex[arr[offset + 11]] +
-    byteToHex[arr[offset + 12]] +
-    byteToHex[arr[offset + 13]] +
-    byteToHex[arr[offset + 14]] +
-    byteToHex[arr[offset + 15]]
-  ).toLowerCase();
+  let uuid = '';
+  uuid += byteToHex[arr[offset + 0]];
+  uuid += byteToHex[arr[offset + 1]];
+  uuid += byteToHex[arr[offset + 2]];
+  uuid += byteToHex[arr[offset + 3]];
+  uuid += '-';
+  uuid += byteToHex[arr[offset + 4]];
+  uuid += byteToHex[arr[offset + 5]];
+  uuid += '-';
+  uuid += byteToHex[arr[offset + 6]];
+  uuid += byteToHex[arr[offset + 7]];
+  uuid += '-';
+  uuid += byteToHex[arr[offset + 8]];
+  uuid += byteToHex[arr[offset + 9]];
+  uuid += '-';
+  uuid += byteToHex[arr[offset + 10]];
+  uuid += byteToHex[arr[offset + 11]];
+  uuid += byteToHex[arr[offset + 12]];
+  uuid += byteToHex[arr[offset + 13]];
+  uuid += byteToHex[arr[offset + 14]];
+  uuid += byteToHex[arr[offset + 15]];
+  return uuid.toLowerCase();
 }
 
 function stringify(arr, offset = 0) {


### PR DESCRIPTION
The only change made was moving away from the + operator, using string concatenation instead.
An invisible, yet valuable change IMO.

The explanation is pretty simple: The + operator creates a new string on each operation, which can be inefficient when concatenating a large number of strings, or in this case, concatenating different "chunks" multiple times.

@broofa I just saw your comment on my other pull request, yet I was already preparing this PR, so please let me know if this can be valid or performance isn't taken in consideration at all even in these cases, I'll stop going for it if it is the case ofc :)

Before:
```
Starting. Tests take ~1 minute to run ...
uuid.stringify() x 1,599,033 ops/sec ±1.74% (83 runs sampled)
uuid.parse() x 1,668,695 ops/sec ±2.76% (90 runs sampled)
---

uuid.v1() x 1,053,405 ops/sec ±1.34% (89 runs sampled)
uuid.v1() fill existing array x 2,140,536 ops/sec ±1.81% (92 runs sampled)
uuid.v4() x 8,738,755 ops/sec ±1.92% (86 runs sampled)
uuid.v4() fill existing array x 2,978,811 ops/sec ±0.34% (92 runs sampled)
uuid.v3() x 156,645 ops/sec ±2.54% (70 runs sampled)
uuid.v5() x 177,174 ops/sec ±2.65% (68 runs sampled)
Fastest is uuid.v4()
```

After:
```
Starting. Tests take ~1 minute to run ...
uuid.stringify() x 1,726,349 ops/sec ±0.56% (91 runs sampled)
uuid.parse() x 1,704,779 ops/sec ±0.50% (95 runs sampled)
---

uuid.v1() x 1,089,921 ops/sec ±0.34% (93 runs sampled)
uuid.v1() fill existing array x 2,210,764 ops/sec ±0.39% (89 runs sampled)
uuid.v4() x 9,479,529 ops/sec ±2.45% (86 runs sampled)
uuid.v4() fill existing array x 3,063,681 ops/sec ±1.19% (96 runs sampled)
uuid.v3() x 156,433 ops/sec ±2.42% (73 runs sampled)
uuid.v5() x 173,674 ops/sec ±2.46% (71 runs sampled)
Fastest is uuid.v4()
```

