### PR TITLE
perf: remove superfluous call to toLowerCase

### DIFF
--- a/src/stringify.js
+++ b/src/stringify.js
@@ -34,7 +34,7 @@ export function unsafeStringify(arr, offset = 0) {
     byteToHex[arr[offset + 13]] +
     byteToHex[arr[offset + 14]] +
     byteToHex[arr[offset + 15]]
-  ).toLowerCase();
+  );
 }
 
 function stringify(arr, offset = 0) {


### PR DESCRIPTION
From the discussion and experimentation in #676 I found that we are running `toLowerCase` on every generated id instead of once when constructing `byteToHex`.

In fact, `toString(16)` seems to already return lower case, but I cannot be sure that this is guaranteed by the spec after reading it, and since it doesn't do any harm I kept it:

https://tc39.es/ecma262/multipage/ecmascript-data-types-and-values.html#sec-numeric-types-number-tostring

`npm run test:benchmark` is returning some strange results though:

Name | Before change | After change
---- | ------------- | ------------
uuid.stringify() | x 4,494,323 ops/sec ±0.14% | x 3,529,389 ops/sec ±0.13%
uuid.parse() | x 4,021,155 ops/sec ±0.05% | x 4,015,847 ops/sec ±0.06%
uuid.v1() | x 4,612,946 ops/sec ±0.18% | x 6,409,517 ops/sec ±0.12%
uuid.v1() fill existing array | x 10,069,463 ops/sec ±0.13% | x 10,022,300 ops/sec ±0.13%
uuid.v4() | x 22,898,259 ops/sec ±1.66% | x 23,060,288 ops/sec ±1.67%
uuid.v4() fill existing array | x 8,156,566 ops/sec ±0.23% | x 8,225,266 ops/sec ±0.20%
uuid.v3() | x 560,691 ops/sec ±0.28% | x 600,164 ops/sec ±0.32%
uuid.v5() | x 665,117 ops/sec ±0.43% | x 639,418 ops/sec ±0.31%

`uuid.v1` is much faster, but `uuid.stringify` is slower? 🤔 

If I benchmark this with `hyperfine` (see #676 for details) then this `unsafeStringify` is 1.66 times faster than the one currently in `main`.

The only thing I can think would cause `stringify` to be slower, would be if V8 sets some kind of "is ascii" or similar flag on the string when running `toLowerCase`, and then uses this flag to chose another regex engine 🤷‍♂️ 

Indeed, adding `toLowerCase` to the `validate` function (before passing it to an case-insensitive regex 😅) brings the speed of the `uuid.stringify()` up to `x 4,465,165 ops/sec ±0.12% (98 runs sampled)` again.

<details>
<summary>Hyperfine seems to support this:</summary>

**`lc-1.js`**

```js
const byteToHex = [];

for (let i = 0; i < 256; ++i) {
  byteToHex.push((i + 0x100).toString(16).slice(1));
}

function unsafeStringify(arr, offset = 0) {
  // Note: Be careful editing this code!  It's been tuned for performance
  // and works in ways you may not expect. See https://github.com/uuidjs/uuid/pull/434
  return (
    byteToHex[arr[offset + 0]] +
    byteToHex[arr[offset + 1]] +
    byteToHex[arr[offset + 2]] +
    byteToHex[arr[offset + 3]] +
    '-' +
    byteToHex[arr[offset + 4]] +
    byteToHex[arr[offset + 5]] +
    '-' +
    byteToHex[arr[offset + 6]] +
    byteToHex[arr[offset + 7]] +
    '-' +
    byteToHex[arr[offset + 8]] +
    byteToHex[arr[offset + 9]] +
    '-' +
    byteToHex[arr[offset + 10]] +
    byteToHex[arr[offset + 11]] +
    byteToHex[arr[offset + 12]] +
    byteToHex[arr[offset + 13]] +
    byteToHex[arr[offset + 14]] +
    byteToHex[arr[offset + 15]]
  );
}

const arr = [195, 134, 237, 159, 29, 92, 23, 173, 126, 71, 146, 180, 222, 111, 192, 148];
const regex =
  /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|00000000-0000-0000-0000-000000000000)$/i;

const string = unsafeStringify(arr);

for (let i = 0; i < 40_000_000; i++) {
  regex.test(string);
}
```

**`lc-2.js`** (diff)

```diff
--- lc-1.js	2023-01-11 18:55:02
+++ lc-2.js	2023-01-11 18:52:40
@@ -35,7 +35,7 @@
 const regex =
   /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|00000000-0000-0000-0000-000000000000)$/i;
 
-const string = unsafeStringify(arr);
+const string = unsafeStringify(arr).toLowerCase();
 
 for (let i = 0; i < 40_000_000; i++) {
   regex.test(string);
```

```bash
$ hyperfine 'node lc-1a.js' 'node lc-2a.js'
Benchmark 1: node lc-1a.js
  Time (mean ± σ):      2.714 s ±  0.002 s    [User: 2.703 s, System: 0.009 s]
  Range (min … max):    2.712 s …  2.716 s    10 runs
 
Benchmark 2: node lc-2a.js
  Time (mean ± σ):      2.718 s ±  0.006 s    [User: 2.706 s, System: 0.010 s]
  Range (min … max):    2.712 s …  2.727 s    10 runs
 
Summary
  'node lc-1a.js' ran
    1.00 ± 0.00 times faster than 'node lc-2a.js'
```

</details>

-----

I've created a test case that shows the current code we have, the changes proposed in this PR, and a third option that adds `.toLowerCase` only in the "safe" `stringify` function.

https://jsbench.me/u4lcs1i0oy/1

In Safari, the solution here faster. But on V8, probably due to the quirk mentioned above, calling `toLowerCase` before passing to `Regex#test` is faster, so both 1 & 3 is faster.

I'm not really sure what is best to optimize for, but this PR should improve performance on every runtime for the `v1`, `v3`, `v4`, and `v5` functions. If we on top of that want to insert a weird optimization (calling `toLowerCase` before `Regex#test`) just to optimize on V8, that's fine with me.

-----

Even without the performance benefits, I also think that this code change makes sense. Why lowercase the result every time, instead of building it from parts with the correct case from the beginning?