### PR TITLE
Exempt stale

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -12,13 +12,13 @@ jobs:
     steps:
       - uses: actions/stale@v5
         with:
-          days-before-issue-stale: 90
+          close-issue-message: 'Closing issue due to 30 days since being marked as stale.'
           days-before-issue-close: 30
+          days-before-issue-stale: 90
+          days-before-pr-close: -1
+          days-before-pr-stale: -1
+          exempt-issue-labels: ['stale-exempt']
+          exempt-pr-labels: ['stale-exempt']
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-label: 'stale'
           stale-issue-message: 'Marking as stale due to 90 days with no activity.'
-          close-issue-message: 'Closing issue due to 30 days since being marked as stale.'
-          days-before-pr-stale: -1
-          days-before-pr-close: -1
-          exempt-pr-labels: ['stale-exempt']
-          exempt-issue-labels: ['stale-exempt']
-          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -1,7 +1,7 @@
 name: Close inactive issues
 on:
   schedule:
-    - cron: "45 2 * * *"
+    - cron: '45 2 * * *'
 
 jobs:
   close-issues:
@@ -14,9 +14,11 @@ jobs:
         with:
           days-before-issue-stale: 90
           days-before-issue-close: 30
-          stale-issue-label: "stale"
-          stale-issue-message: "Marking as stale due to 90 days with no activity."
-          close-issue-message: "Closing issue due to 30 days since being marked as stale."
+          stale-issue-label: 'stale'
+          stale-issue-message: 'Marking as stale due to 90 days with no activity.'
+          close-issue-message: 'Closing issue due to 30 days since being marked as stale.'
           days-before-pr-stale: -1
           days-before-pr-close: -1
+          exempt-pr-labels: ['stale-exempt']
+          exempt-issue-labels: ['stale-exempt']
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Allows us to add the `stale-exempt` label to a PR or issue to keep it from getting marked as stale.

I just added the `exempt-issue-labels` and `exempt-pr-labels` keys here.   The other changes are just me sorting the keys.