### PR TITLE
ci: run browser tests on pull_request_target

### DIFF
--- a/.github/workflows/browser.yml
+++ b/.github/workflows/browser.yml
@@ -1,25 +1,28 @@
 name: Browser
 
-on: [push]
+on:
+  push:
+  pull_request_target:
+    types: [labeled]
 
 jobs:
   browser:
-
+    if: github.repository == 'uuidjs/uuid' && (contains(github.event.pull_request.labels.*.name, 'safe to test') || github.event_name == 'push')
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
     steps:
-    - uses: actions/checkout@v1
-      with:
-        fetch-depth: 10
+    - uses: actions/checkout@v3
     - name: Use Node.js 16.x
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: 16.x
-    - run: npm install
+    - run: npm ci
     - name: Test Browser
       run: npm run test:browser
       env:
-        CI: true
         BROWSERSTACK_USER: ${{ secrets.BROWSERSTACK_USER }}
         BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+    - run: npx bundlewatch --config bundlewatch.config.json
+      env:
+        BUNDLEWATCH_GITHUB_TOKEN: ${{ secrets.BUNDLEWATCH_GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,6 @@ jobs:
       if: matrix.node-version == '16.x'
     - run: npm run docs:diff
       if: matrix.node-version == '16.x'
-    - run: npm run bundlewatch
-      if: matrix.node-version == '16.x'
-      env:
-        BUNDLEWATCH_GITHUB_TOKEN: ${{ secrets.BUNDLEWATCH_GITHUB_TOKEN }}
     - run: npm run test:node
       if: matrix.node-version >= '16.x'
     - run: npm run test:pack


### PR DESCRIPTION
`pull_request_target` allows runs to access the secret values. Since this adds an attack vector described here https://securitylab.github.com/research/github-actions-preventing-pwn-requests/ I added the extra condition to only run on the main repo `push` or if someone adds a `safe to test` label after reviewing the code