### PR TITLE
ci: pass commit SHA to bundlewatch

### DIFF
--- a/.github/workflows/browser.yml
+++ b/.github/workflows/browser.yml
@@ -26,3 +26,4 @@ jobs:
     - run: npx bundlewatch --config bundlewatch.config.json
       env:
         BUNDLEWATCH_GITHUB_TOKEN: ${{ secrets.BUNDLEWATCH_GITHUB_TOKEN }}
+        CI_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}


### PR DESCRIPTION
Try using the workaround in https://github.com/bundlewatch/bundlewatch/issues/220#issuecomment-763438369 with a fallback to the `github.sha` for pushes