### PR TITLE
Support "react-native" package entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,11 @@
         "import": "./dist/esm-browser/index.js",
         "require": "./dist/commonjs-browser/index.js"
       },
+      "react-native": {
+        "module": "./dist/esm-node/index.js",
+        "require": "./dist/index.js",
+        "import": "./wrapper.mjs"
+      },
       "default": "./dist/esm-browser/index.js"
     },
     "./package.json": "./package.json"


### PR DESCRIPTION
Adds conditional export for `react-native` environment.

This fixes UUID not working in Jest with the `react-native` preset. Before this change it was falling back to default and then failing to find the global `crypto`.

`react-native` inserted after `browser` so React Native for Web can still be targeted properly, see https://nodejs.org/api/packages.html#community-conditions-definitions for more info.

<!--
Thank you for your contribution!

If your pull request contains considerable changes please run the benchmark before and after your
changes and include the results in the pull request description. To run the benchmark execute:

    npm run test:benchmark

from the root of this repository.
-->
