### PR TITLE
build: use node:crypto not crypto when importing

### DIFF
--- a/src/md5.js
+++ b/src/md5.js
@@ -1,4 +1,4 @@
-import crypto from 'crypto';
+import crypto from 'node:crypto';
 
 function md5(bytes) {
   if (Array.isArray(bytes)) {

--- a/src/native.js
+++ b/src/native.js
@@ -1,3 +1,3 @@
-import crypto from 'crypto';
+import crypto from 'node:crypto';
 
 export default { randomUUID: crypto.randomUUID };

--- a/src/rng.js
+++ b/src/rng.js
@@ -1,4 +1,4 @@
-import crypto from 'crypto';
+import crypto from 'node:crypto';
 
 const rnds8Pool = new Uint8Array(256); // # of random values to pre-allocate
 let poolPtr = rnds8Pool.length;

--- a/src/sha1.js
+++ b/src/sha1.js
@@ -1,4 +1,4 @@
-import crypto from 'crypto';
+import crypto from 'node:crypto';
 
 function sha1(bytes) {
   if (Array.isArray(bytes)) {


### PR DESCRIPTION
<!--
Thank you for your contribution!

If your pull request contains considerable changes please run the benchmark before and after your
changes and include the results in the pull request description. To run the benchmark execute:

    npm run test:benchmark

from the root of this repository.
-->

Cloudflare Workers/Pages work with certain native node libraries (https://developers.cloudflare.com/workers/runtime-apis/nodejs) but for them to work correctly they need to be imported with `node:crypto` instead of `crypto` (for example).

This PR updates `uuid` so it imports from `node:crypto` to resolve this issue.
