### PR TITLE
chore: enable corepack w/ npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,5 +131,6 @@
     "scripts": {
       "postchangelog": "prettier --write CHANGELOG.md"
     }
-  }
+  },
+  "packageManager": "npm@10.8.1+sha256.b8807aebb9656758e2872fa6e7c564b506aa2faa9297439a478d471d2fe32483"
 }


### PR DESCRIPTION
This makes it clear which package manager we're using.