### PR TITLE
fix: revert 677 for v9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [9.0.1](https://github.com/uuidjs/uuid/compare/v9.0.0...v9.0.1) (2023-09-12)
+
 ## [9.0.0](https://github.com/uuidjs/uuid/compare/v8.3.2...v9.0.0) (2022-09-05)
 
 ### ⚠ BREAKING CHANGES

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "uuid",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "uuid",
-      "version": "9.0.0",
+      "version": "9.0.1",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uuid",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "description": "RFC4122 (v1, v4, and v5) UUIDs",
   "funding": [
     "https://github.com/sponsors/broofa",

--- a/src/stringify.js
+++ b/src/stringify.js
@@ -13,6 +13,9 @@ for (let i = 0; i < 256; ++i) {
 export function unsafeStringify(arr, offset = 0) {
   // Note: Be careful editing this code!  It's been tuned for performance
   // and works in ways you may not expect. See https://github.com/uuidjs/uuid/pull/434
+  //
+  // Note to future-self: No, you can't remove the `toLowerCase()` call.
+  // REF: https://github.com/uuidjs/uuid/pull/677#issuecomment-1757351351
   return (
     byteToHex[arr[offset + 0]] +
     byteToHex[arr[offset + 1]] +
@@ -34,7 +37,7 @@ export function unsafeStringify(arr, offset = 0) {
     byteToHex[arr[offset + 13]] +
     byteToHex[arr[offset + 14]] +
     byteToHex[arr[offset + 15]]
-  );
+  ).toLowerCase();
 }
 
 function stringify(arr, offset = 0) {


### PR DESCRIPTION
Restoring the `toLowerCase()` perf optimization for v9 release(s), [per our conversation in the v10 release](https://github.com/uuidjs/uuid/pull/760#discussion_r1632004447).