### PR TITLE
fix(v7): seq_hi shift for byte 6

### DIFF
--- a/src/v7.js
+++ b/src/v7.js
@@ -125,7 +125,7 @@ function v7(options, buf, offset) {
   b[i++] = _msecs & 0xff;
 
   // [byte 6] - set 4 bits of version (7) with first 4 bits seq_hi
-  b[i++] = ((seqHigh >>> 4) & 0x0f) | 0x70;
+  b[i++] = ((seqHigh >>> 8) & 0x0f) | 0x70;
 
   // [byte 7] remaining 8 bits of seq_hi
   b[i++] = seqHigh & 0xff;

--- a/test/unit/v7.test.js
+++ b/test/unit/v7.test.js
@@ -1,6 +1,6 @@
 import assert from 'assert';
 import v7 from '../../src/v7.js';
-import parse from '../../src/parse.js';
+import stringify from '../../src/stringify.js';
 
 /**
  * fixture bit layout:
@@ -172,6 +172,7 @@ describe('v7', () => {
   });
 
   test('flipping bits changes the result', () => {
+    const asBigInt = (buf) => buf.reduce((l, r) => (BigInt(l) << 8n) | BigInt(r));
     const flip = (data, n) => data ^ (1n << (127n - n));
     const optionsFrom = (data) => {
       const ms = data >> (128n - 48n);
@@ -190,13 +191,16 @@ describe('v7', () => {
         ],
       };
     };
-    const id = v7();
-    const data = parse(id).reduce((l, r) => (BigInt(l) << 8n) | BigInt(r));
+    const buf = new Uint8Array(16);
+    const data = asBigInt(v7({}, buf));
+    const id = stringify(buf);
     for (let i = 0; i < 128; ++i) {
       if ([48, 49, 50, 51, 64, 65].includes(i)) {
         continue;
       }
-      assert(v7(optionsFrom(flip(data, BigInt(i)))) !== id);
+      const flipped = flip(data, BigInt(i));
+      assert(asBigInt(v7(optionsFrom(flipped), buf)) === flipped);
+      assert(stringify(buf) !== id);
     }
   });
 });


### PR DESCRIPTION
A typo that fits just right in the rfc example blind spot. 