### PR TITLE
fix!: refactor v7 internal state and options logic, fixes #764

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,10 +338,10 @@ Create an RFC version 7 (random) UUID
 |  |  |
 | --- | --- |
 | [`options`] | `Object` with one or more of the following properties: |
-| [`options.msecs`] | RFC "timestamp" field (`Number` of milliseconds, unix epoch) |
+| [`options.msecs`] | RFC "timestamp" field (`Number` of milliseconds, unix epoch). Default = `Date.now()` |
 | [`options.random`] | `Array` of 16 random bytes (0-255) |
 | [`options.rng`] | Alternative to `options.random`, a `Function` that returns an `Array` of 16 random bytes (0-255) |
-| [`options.seq`] | 31 bit monotonic sequence counter as `Number` between 0 - 0x7fffffff |
+| [`options.seq`] | 32-bit sequence `Number` between 0 - 0xffffffff. This may be provided to help insure uniqueness for UUIDs generated within the same millisecond time interval. Default = random value. |
 | [`buffer`] | `Array \| Buffer` If specified, uuid will be written here in byte-form, starting at `offset` |
 | [`offset` = 0] | `Number` Index to start writing UUID bytes in `buffer` |
 | _returns_ | UUID `String` if no `buffer` is specified, otherwise returns `buffer` |

--- a/README_js.md
+++ b/README_js.md
@@ -346,10 +346,10 @@ Create an RFC version 7 (random) UUID
 |  |  |
 | --- | --- |
 | [`options`] | `Object` with one or more of the following properties: |
-| [`options.msecs`] | RFC "timestamp" field (`Number` of milliseconds, unix epoch) |
+| [`options.msecs`] | RFC "timestamp" field (`Number` of milliseconds, unix epoch). Default = `Date.now()` |
 | [`options.random`] | `Array` of 16 random bytes (0-255) |
 | [`options.rng`] | Alternative to `options.random`, a `Function` that returns an `Array` of 16 random bytes (0-255) |
-| [`options.seq`] | 31 bit monotonic sequence counter as `Number` between 0 - 0x7fffffff |
+| [`options.seq`] | 32-bit sequence `Number` between 0 - 0xffffffff. This may be provided to help insure uniqueness for UUIDs generated within the same millisecond time interval. Default = random value. |
 | [`buffer`] | `Array \| Buffer` If specified, uuid will be written here in byte-form, starting at `offset` |
 | [`offset` = 0] | `Number` Index to start writing UUID bytes in `buffer` |
 | _returns_ | UUID `String` if no `buffer` is specified, otherwise returns `buffer` |

--- a/package.json
+++ b/package.json
@@ -115,8 +115,8 @@
     "test:browser": "wdio run ./wdio.conf.js",
     "test:node": "npm-run-all --parallel examples:node:**",
     "test:pack": "./scripts/testpack.sh",
-    "test:watch": "node --test --watch dist/esm/test",
-    "test": "node --test dist/esm/test"
+    "test:watch": "node --test --enable-source-maps --watch dist/esm/test",
+    "test": "node --test --enable-source-maps dist/esm/test"
   },
   "repository": {
     "type": "git",

--- a/src/v7.ts
+++ b/src/v7.ts
@@ -2,154 +2,107 @@ import { UUIDTypes, Version7Options } from './_types.js';
 import rng from './rng.js';
 import { unsafeStringify } from './stringify.js';
 
-/**
- * UUID V7 - Unix Epoch time-based UUID
- *
- * The IETF has published RFC9562, introducing 3 new UUID versions (6,7,8). This
- * implementation of V7 is based on the accepted, though not yet approved,
- * revisions.
- *
- * RFC 9562:https://www.rfc-editor.org/rfc/rfc9562.html Universally Unique
- * IDentifiers (UUIDs)
+type V7State = {
+  msecs: number;
+  seq: number;
+};
 
- *
- * Sample V7 value:
- * https://www.rfc-editor.org/rfc/rfc9562.html#name-example-of-a-uuidv7-value
- *
- * Monotonic Bit Layout: RFC rfc9562.6.2 Method 1, Dedicated Counter Bits ref:
- *     https://www.rfc-editor.org/rfc/rfc9562.html#section-6.2-5.1
- *
- *   0                   1                   2                   3 0 1 2 3 4 5 6
- *   7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
- *  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
- *  |                          unix_ts_ms                           |
- *  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
- *  |          unix_ts_ms           |  ver  |        seq_hi         |
- *  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
- *  |var|               seq_low               |        rand         |
- *  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
- *  |                             rand                              |
- *  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
- *
- * seq is a 31 bit serialized counter; comprised of 12 bit seq_hi and 19 bit
- * seq_low, and randomly initialized upon timestamp change. 31 bit counter size
- * was selected as any bitwise operations in node are done as _signed_ 32 bit
- * ints. we exclude the sign bit.
- */
-
-let _seqLow: number | null = null;
-let _seqHigh: number | null = null;
-let _msecs = 0;
+const _state: V7State = {
+  msecs: -Infinity, // time, milliseconds
+  seq: 0, // sequence number (32-bits)
+};
 
 function v7(options?: Version7Options, buf?: undefined, offset?: number): string;
 function v7(options?: Version7Options, buf?: Uint8Array, offset?: number): Uint8Array;
 function v7(options?: Version7Options, buf?: Uint8Array, offset?: number): UUIDTypes {
-  options ??= {};
+  let bytes: Uint8Array;
 
-  // initialize buffer and pointer
-  let i = (buf && offset) || 0;
-  const b = buf || new Uint8Array(16);
-
-  // rnds is Uint8Array(16) filled with random bytes
-  const rnds = options.random || (options.rng || rng)();
-
-  // milliseconds since unix epoch, 1970-01-01 00:00
-  const msecs = options.msecs !== undefined ? options.msecs : Date.now();
-
-  // seq is user provided 31 bit counter
-  let seq = options.seq !== undefined ? options.seq : null;
-
-  // initialize local seq high/low parts
-  let seqHigh = _seqHigh;
-  let seqLow = _seqLow;
-
-  // check if clock has advanced and user has not provided msecs
-  if (msecs > _msecs && options.msecs === undefined) {
-    _msecs = msecs;
-
-    // unless user provided seq, reset seq parts
-    if (seq !== null) {
-      seqHigh = null;
-      seqLow = null;
-    }
-  }
-
-  // if we have a user provided seq
-  if (seq !== null) {
-    // trim provided seq to 31 bits of value, avoiding overflow
-    if (seq > 0x7fffffff) {
-      seq = 0x7fffffff;
-    }
-
-    // split provided seq into high/low parts
-    seqHigh = (seq >>> 19) & 0xfff;
-    seqLow = seq & 0x7ffff;
-  }
-
-  // randomly initialize seq
-  if (seqHigh === null || seqLow === null) {
-    seqHigh = rnds[6] & 0x7f;
-    seqHigh = (seqHigh << 8) | rnds[7];
-
-    seqLow = rnds[8] & 0x3f; // pad for var
-    seqLow = (seqLow << 8) | rnds[9];
-    seqLow = (seqLow << 5) | (rnds[10] >>> 3);
-  }
-
-  // increment seq if within msecs window
-  if (msecs + 10000 > _msecs && seq === null) {
-    if (++seqLow > 0x7ffff) {
-      seqLow = 0;
-
-      if (++seqHigh > 0xfff) {
-        seqHigh = 0;
-
-        // increment internal _msecs. this allows us to continue incrementing
-        // while staying monotonic. Note, once we hit 10k milliseconds beyond system
-        // clock, we will reset breaking monotonicity (after (2^31)*10000 generations)
-        _msecs++;
-      }
-    }
+  if (options) {
+    // w/ options: Make UUID independent of internal state
+    bytes = v7Bytes(
+      options.random ?? options.rng?.() ?? rng(),
+      options.msecs,
+      options.seq,
+      buf,
+      offset
+    );
   } else {
-    // resetting; we have advanced more than
-    // 10k milliseconds beyond system clock
-    _msecs = msecs;
+    // No options: Use internal state
+    const now = Date.now();
+    const rnds = rng();
+
+    updateV7State(_state, now, rnds);
+
+    bytes = v7Bytes(rnds, _state.msecs, _state.seq, buf, offset);
   }
 
-  _seqHigh = seqHigh;
-  _seqLow = seqLow;
+  return buf ? bytes : unsafeStringify(bytes);
+}
+
+// (Private!)  Do not use.  This method is only exported for testing purposes
+// and may change without notice.
+export function updateV7State(state: V7State, now: number, rnds: Uint8Array) {
+  if (now > state.msecs) {
+    // Time has moved on! Pick a new random sequence number
+    state.seq = (rnds[6] << 23) | (rnds[7] << 16) | (rnds[8] << 8) | rnds[9];
+    state.msecs = now;
+  } else {
+    // Bump sequence counter w/ 32-bit rollover
+    state.seq = (state.seq + 1) | 0;
+
+    // Handle rollover case by bumping timestamp to preserve monotonicity. This
+    // is allowed by the RFC and will self-correct as the system clock catches
+    // up. See https://www.rfc-editor.org/rfc/rfc9562.html#section-6.2-9.4
+    if (state.seq === 0) {
+      state.msecs++;
+    }
+  }
+
+  return state;
+}
+
+function v7Bytes(
+  rnds: Uint8Array,
+  msecs: number | undefined,
+  seq: number | undefined,
+  buf = new Uint8Array(16),
+  offset = 0
+) {
+  // Defaults
+  msecs ??= Date.now();
+  seq ??= ((rnds[6] * 0x7f) << 24) | (rnds[7] << 16) | (rnds[8] << 8) | rnds[9];
 
   // [bytes 0-5] 48 bits of local timestamp
-  b[i++] = (_msecs / 0x10000000000) & 0xff;
-  b[i++] = (_msecs / 0x100000000) & 0xff;
-  b[i++] = (_msecs / 0x1000000) & 0xff;
-  b[i++] = (_msecs / 0x10000) & 0xff;
-  b[i++] = (_msecs / 0x100) & 0xff;
-  b[i++] = _msecs & 0xff;
+  buf[offset++] = (msecs / 0x10000000000) & 0xff;
+  buf[offset++] = (msecs / 0x100000000) & 0xff;
+  buf[offset++] = (msecs / 0x1000000) & 0xff;
+  buf[offset++] = (msecs / 0x10000) & 0xff;
+  buf[offset++] = (msecs / 0x100) & 0xff;
+  buf[offset++] = msecs & 0xff;
 
-  // [byte 6] - set 4 bits of version (7) with first 4 bits seq_hi
-  b[i++] = ((seqHigh >>> 8) & 0x0f) | 0x70;
+  // [byte 6] - `version` | seq bits 31-28 (4 bits)
+  buf[offset++] = 0x70 | ((seq >>> 27) & 0x0f);
 
-  // [byte 7] remaining 8 bits of seq_hi
-  b[i++] = seqHigh & 0xff;
+  // [byte 7] seq bits 27-20 (8 bits)
+  buf[offset++] = (seq >>> 19) & 0xff;
 
-  // [byte 8] - variant (2 bits), first 6 bits seq_low
-  b[i++] = ((seqLow >>> 13) & 0x3f) | 0x80;
+  // [byte 8] - `variant` (2 bits) | seq bits 19-14 (6 bits)
+  buf[offset++] = ((seq >>> 13) & 0x3f) | 0x80;
 
-  // [byte 9] 8 bits seq_low
-  b[i++] = (seqLow >>> 5) & 0xff;
+  // [byte 9] seq bits 13-6 (8 bits)
+  buf[offset++] = (seq >>> 5) & 0xff;
 
-  // [byte 10] remaining 5 bits seq_low, 3 bits random
-  b[i++] = ((seqLow << 3) & 0xff) | (rnds[10] & 0x07);
+  // [byte 10] seq bits 5-0 (6 bits) | random (2 bits)
+  buf[offset++] = ((seq << 3) & 0xff) | (rnds[10] & 0x07);
 
   // [bytes 11-15] always random
-  b[i++] = rnds[11];
-  b[i++] = rnds[12];
-  b[i++] = rnds[13];
-  b[i++] = rnds[14];
-  b[i++] = rnds[15];
+  buf[offset++] = rnds[11];
+  buf[offset++] = rnds[12];
+  buf[offset++] = rnds[13];
+  buf[offset++] = rnds[14];
+  buf[offset++] = rnds[15];
 
-  return buf || unsafeStringify(b);
+  return buf;
 }
 
 export default v7;


### PR DESCRIPTION
Putting this PR up as an alternative to #768 that addresses #764 and a few other concerns.

* Written in Typescript (required now that #763 has landed)
* Decouple behavior of `v7()`-with-options from `v7()`-without-options.
* Encapsulate internal state handling and refactor to be more idiomatic
* Rigorous unit tests for internal state transitions
* Use 32-bit `seq` field rather than 31.

@robinpokorny My apologies for closing #768.  I wanted to merge it, but the switch to typescript and these other issues just made it easier to address in a new PR.  I'll do my best to credit your work here.

... and if you could help review this, I'd appreciate it. I feel pretty good about this refactor but there's enough code churn that an extra set of eyes would be very helpful.

Where #764 is concerned, the heart of this PR is [in this code](https://github.com/uuidjs/uuid/blob/894b6299c72c019c7b2a5897f41f60c8e390fb05/src/v7.ts#L20-L37), where the behavior very deliberately branches based on whether `options` are present.

> [!NOTE]
> * 'Marking this as a breaking change because of the changes to default values for `options#seq` and `options#msecs`.
> * The `v1()` code would probably benefit from a similar refactoring, if for nothing else than to make the APIs consistent.  I'll put up a PR for that shortly.
