### PR TITLE
fix: remove v4 options default assignment preventing native.randomUUID from being used

### DIFF
--- a/src/test/v4.test.ts
+++ b/src/test/v4.test.ts
@@ -1,6 +1,7 @@
 import * as assert from 'assert';
-import test, { describe } from 'node:test';
+import test, { describe, mock } from 'node:test';
 import v4 from '../v4.js';
+import native from '../native.js';
 
 const randomBytesFixture = Uint8Array.of(
   0x10,
@@ -46,6 +47,26 @@ describe('v4', () => {
     const id2 = v4();
 
     assert.ok(id1 !== id2);
+  });
+
+  test('should uses native randomUUID() if no option is passed', () => {
+    mock.method(native, 'randomUUID');
+
+    assert.equal((native.randomUUID as any).mock.callCount(), 0);
+    v4();
+    assert.equal((native.randomUUID as any).mock.callCount(), 1);
+
+    mock.restoreAll();
+  });
+
+  test('should not use native randomUUID() if an option is passed', () => {
+    mock.method(native, 'randomUUID');
+
+    assert.equal((native.randomUUID as any).mock.callCount(), 0);
+    v4({});
+    assert.equal((native.randomUUID as any).mock.callCount(), 0);
+
+    mock.restoreAll();
   });
 
   test('explicit options.random produces expected result', () => {

--- a/src/v4.ts
+++ b/src/v4.ts
@@ -6,8 +6,6 @@ import { unsafeStringify } from './stringify.js';
 function v4(options?: Version4Options, buf?: undefined, offset?: number): string;
 function v4(options?: Version4Options, buf?: Uint8Array, offset?: number): Uint8Array;
 function v4(options?: Version4Options, buf?: Uint8Array, offset?: number): UUIDTypes {
-  options ??= {};
-
   if (native.randomUUID && !buf && !options) {
     return native.randomUUID();
   }


### PR DESCRIPTION
This removes the v4 options default assignment introduced during porting to ts (by mistake maybe?), during https://github.com/uuidjs/uuid/pull/763 - [PR diff](https://github.com/uuidjs/uuid/pull/763/files#diff-d7d9279b5eb8b7335eff565ca2e9a7e9ec8ff7d7de248197ce80481c118ea5de) - [commit](https://github.com/uuidjs/uuid/commit/1e0f9870db864ca93f7a69db0d468b5e1b7605e7#diff-d7d9279b5eb8b7335eff565ca2e9a7e9ec8ff7d7de248197ce80481c118ea5de) preventing `native.randomUUID` from being used

if `options` always have a value, we will never enter the if in line 11. `{}`  will be assigned to `options` in line 15 after the native check

it looks to me that the line 9 statement is added by mistake