### PR TITLE
README says uuid@11 has been published (including types), but latest version on NPM is uuid@10 (doesn't include types)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,11 +29,19 @@
       "node": {
         "module": "./dist/esm/index.js",
         "require": "./dist/cjs/index.js",
-        "import": "./wrapper.mjs"
+        "import": "./wrapper.mjs",
+        "types": {
+          "import": "./dist/esm/index.d.ts",
+          "default": "./dist/cjs/index.d.ts"
+        }
       },
       "browser": {
         "import": "./dist/esm-browser/index.js",
-        "require": "./dist/cjs-browser/index.js"
+        "require": "./dist/cjs-browser/index.js",
+        "types": {
+          "import": "./dist/esm-browser/index.d.ts",
+          "default": "./dist/cjs-browser/index.d.ts"
+        }
       },
       "default": "./dist/esm-browser/index.js"
     },


### PR DESCRIPTION
Even though this project is now built with typescript, I get this error when I use it on my node app:
```
Could not find a declaration file for module 'uuid'. './app/node_modules/uuid/dist/esm-browser/index.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/uuid` if it exists or add a new declaration (.d.ts) file containing `declare module 'uuid';`ts(7016)
```
This fix exports types declaration from `package.json`.