### PR TITLE
fix: remove obsolete code for removed IE11 support

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -20,7 +20,6 @@ export default [
         ...globals.commonjs,
         ...globals.jest,
         ...globals.node,
-        msCrypto: true,
       },
     },
   },


### PR DESCRIPTION
IE11 / `msCrypto` was removed with release v9.