### PR TITLE
chore: add id to RP workflow step

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           token: ${{ secrets.UUID_RELEASE_PLEASE_TOKEN }}
           release-type: node


### PR DESCRIPTION
'Think I found the problem with the RP workflow not running the `npm  publish` steps: The `release-please-action` step was missing an `id`, meaning `steps.release.outputs.release_created` wasn't getting set properly.