### PR TITLE
chore: update to actions/checkout@v4

### DIFF
--- a/.github/workflows/browser.yml
+++ b/.github/workflows/browser.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 10
       - name: Use Node.js 20.x


### PR DESCRIPTION
Fixes this warning: 
![CleanShot 2024-10-31 at 07 02 23@2x](https://github.com/user-attachments/assets/7c5d13e0-73d3-4ffd-b94e-12c2a8851e21)
