### PR TITLE
fix: apply stricter typing to the v* signatures

### DIFF
--- a/src/v1.ts
+++ b/src/v1.ts
@@ -25,7 +25,7 @@ type V1State = {
 const _state: V1State = {};
 
 function v1(options?: Version1Options, buf?: undefined, offset?: number): string;
-function v1(options?: Version1Options, buf?: Uint8Array, offset?: number): Uint8Array;
+function v1(options: Version1Options | undefined, buf: Uint8Array, offset?: number): Uint8Array;
 function v1(options?: Version1Options, buf?: Uint8Array, offset?: number): UUIDTypes {
   let bytes: Uint8Array;
 

--- a/src/v3.ts
+++ b/src/v3.ts
@@ -4,18 +4,6 @@ import v35, { DNS, URL } from './v35.js';
 
 export { DNS, URL } from './v35.js';
 
-function v3(
-  value: string | Uint8Array,
-  namespace: UUIDTypes,
-  buf?: undefined,
-  offset?: number
-): string;
-function v3(
-  value: string | Uint8Array,
-  namespace: UUIDTypes,
-  buf: Uint8Array,
-  offset?: number
-): Uint8Array;
 function v3(value: string | Uint8Array, namespace: UUIDTypes, buf?: Uint8Array, offset?: number) {
   return v35(0x30, md5, value, namespace, buf, offset);
 }

--- a/src/v3.ts
+++ b/src/v3.ts
@@ -13,7 +13,7 @@ function v3(
 function v3(
   value: string | Uint8Array,
   namespace: UUIDTypes,
-  buf?: Uint8Array,
+  buf: Uint8Array,
   offset?: number
 ): Uint8Array;
 function v3(value: string | Uint8Array, namespace: UUIDTypes, buf?: Uint8Array, offset?: number) {

--- a/src/v4.ts
+++ b/src/v4.ts
@@ -4,7 +4,7 @@ import rng from './rng.js';
 import { unsafeStringify } from './stringify.js';
 
 function v4(options?: Version4Options, buf?: undefined, offset?: number): string;
-function v4(options: Version4Options, buf: Uint8Array, offset?: number): Uint8Array;
+function v4(options: Version4Options | undefined, buf: Uint8Array, offset?: number): Uint8Array;
 function v4(options?: Version4Options, buf?: Uint8Array, offset?: number): UUIDTypes {
   if (native.randomUUID && !buf && !options) {
     return native.randomUUID();

--- a/src/v4.ts
+++ b/src/v4.ts
@@ -4,7 +4,7 @@ import rng from './rng.js';
 import { unsafeStringify } from './stringify.js';
 
 function v4(options?: Version4Options, buf?: undefined, offset?: number): string;
-function v4(options?: Version4Options, buf?: Uint8Array, offset?: number): Uint8Array;
+function v4(options: Version4Options, buf: Uint8Array, offset?: number): Uint8Array;
 function v4(options?: Version4Options, buf?: Uint8Array, offset?: number): UUIDTypes {
   if (native.randomUUID && !buf && !options) {
     return native.randomUUID();

--- a/src/v5.ts
+++ b/src/v5.ts
@@ -4,18 +4,6 @@ import v35, { DNS, URL } from './v35.js';
 
 export { DNS, URL } from './v35.js';
 
-function v5(
-  value: string | Uint8Array,
-  namespace: UUIDTypes,
-  buf?: undefined,
-  offset?: number
-): string;
-function v5(
-  value: string | Uint8Array,
-  namespace: UUIDTypes,
-  buf: Uint8Array,
-  offset?: number
-): Uint8Array;
 function v5(value: string | Uint8Array, namespace: UUIDTypes, buf?: Uint8Array, offset?: number) {
   return v35(0x50, sha1, value, namespace, buf, offset);
 }

--- a/src/v5.ts
+++ b/src/v5.ts
@@ -13,7 +13,7 @@ function v5(
 function v5(
   value: string | Uint8Array,
   namespace: UUIDTypes,
-  buf?: Uint8Array,
+  buf: Uint8Array,
   offset?: number
 ): Uint8Array;
 function v5(value: string | Uint8Array, namespace: UUIDTypes, buf?: Uint8Array, offset?: number) {

--- a/src/v6.ts
+++ b/src/v6.ts
@@ -4,7 +4,7 @@ import v1 from './v1.js';
 import v1ToV6 from './v1ToV6.js';
 
 function v6(options?: Version6Options, buf?: undefined, offset?: number): string;
-function v6(options?: Version6Options, buf?: Uint8Array, offset?: number): Uint8Array;
+function v6(options: Version6Options | undefined, buf: Uint8Array, offset?: number): Uint8Array;
 function v6(options?: Version6Options, buf?: Uint8Array, offset?: number): UUIDTypes {
   options ??= {};
   offset ??= 0;

--- a/src/v7.ts
+++ b/src/v7.ts
@@ -10,7 +10,7 @@ type V7State = {
 const _state: V7State = {};
 
 function v7(options?: Version7Options, buf?: undefined, offset?: number): string;
-function v7(options?: Version7Options, buf?: Uint8Array, offset?: number): Uint8Array;
+function v7(options: Version7Options | undefined, buf: Uint8Array, offset?: number): Uint8Array;
 function v7(options?: Version7Options, buf?: Uint8Array, offset?: number): UUIDTypes {
   let bytes: Uint8Array;
 


### PR DESCRIPTION
The `v4` function is guaranteed to return a string unless the `buf` argument is provided. By modifying the signature to denote this parameter as required for the `Uint8Array` case, we get the benefit of a stricter return type of `string` when simply calling `v4()`.