### PR TITLE
fix: exporting types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,10 @@
+export type {
+  UUIDTypes,
+  Version1Options,
+  Version4Options,
+  Version6Options,
+  Version7Options,
+} from './_types.js';
 export { default as MAX } from './max.js';
 export { default as NIL } from './nil.js';
 export { default as parse } from './parse.js';


### PR DESCRIPTION
<!--
Thank you for your contribution!

If your pull request contains considerable changes please run the benchmark before and after your
changes and include the results in the pull request description. To run the benchmark execute:

    npm run test:benchmark

from the root of this repository.
-->

This exports the types from `_types.ts` in the package's entrypoint. Resolves #832 
