### PR TITLE
fix: revert "simplify type for v3 and v5"

### DIFF
--- a/src/v3.ts
+++ b/src/v3.ts
@@ -4,6 +4,18 @@ import v35, { DNS, URL } from './v35.js';
 
 export { DNS, URL } from './v35.js';
 
+function v3(
+  value: string | Uint8Array,
+  namespace: UUIDTypes,
+  buf?: undefined,
+  offset?: number
+): string;
+function v3(
+  value: string | Uint8Array,
+  namespace: UUIDTypes,
+  buf: Uint8Array,
+  offset?: number
+): Uint8Array;
 function v3(value: string | Uint8Array, namespace: UUIDTypes, buf?: Uint8Array, offset?: number) {
   return v35(0x30, md5, value, namespace, buf, offset);
 }

--- a/src/v5.ts
+++ b/src/v5.ts
@@ -4,6 +4,18 @@ import v35, { DNS, URL } from './v35.js';
 
 export { DNS, URL } from './v35.js';
 
+function v5(
+  value: string | Uint8Array,
+  namespace: UUIDTypes,
+  buf?: undefined,
+  offset?: number
+): string;
+function v5(
+  value: string | Uint8Array,
+  namespace: UUIDTypes,
+  buf: Uint8Array,
+  offset?: number
+): Uint8Array;
 function v5(value: string | Uint8Array, namespace: UUIDTypes, buf?: Uint8Array, offset?: number) {
   return v35(0x50, sha1, value, namespace, buf, offset);
 }


### PR DESCRIPTION
As @robbtraister [notes](https://github.com/uuidjs/uuid/pull/831#issuecomment-2455326219), these overloads are necessary to indicate the different return types.

<img src="https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExeGJmdjR6eHpoaGlqa3J0djVkMjR5cGR6ZmlvY3Vidml0MGVkaDRhNSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/ZdmJdMhXnPafh40xJX/giphy.gif" width="200" />