### PR TITLE
fix: compatibility with Typescript V4

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,10 @@
-export type * from './types.js';
+export type {
+  UUIDTypes,
+  Version1Options,
+  Version4Options,
+  Version6Options,
+  Version7Options,
+} from './types.js';
 export { default as MAX } from './max.js';
 export { default as NIL } from './nil.js';
 export { default as parse } from './parse.js';


### PR DESCRIPTION
With https://github.com/uuidjs/uuid/pull/833 the type export was added, but the `export type *` syntax is only available since Typescript V5. Using direct imports should resolve the issue.

See https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-0.html#support-for-export-type- for the documentation on this.

<!--
Thank you for your contribution!

If your pull request contains considerable changes please run the benchmark before and after your
changes and include the results in the pull request description. To run the benchmark execute:

    npm run test:benchmark

from the root of this repository.
-->
