### PR TITLE
docs: Ensure link to getrandomvalues-not-supported is maintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,7 +490,12 @@ Prior to `uuid@11`, it was possible for `options` state to interfere with the in
 
 ## Known issues
 
-### React Native / Expo
+<!-- This header is referenced as an anchor in src/rng-browser.ts -->
+### "getRandomValues() not supported"
+
+This error occurs in environments where the standard [`crypto.getRandomValues()`](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/getRandomValues) API is not supported. This issue can be resolved by adding an appropriate polyfill:
+
+#### React Native / Expo
 
 1. Install [`react-native-get-random-values`](https://github.com/LinusU/react-native-get-random-values#readme)
 1. Import it _before_ `uuid`. Since `uuid` might also appear as a transitive dependency of some other imports it's safest to just import `react-native-get-random-values` as the very first thing in your entry point:

--- a/README_js.md
+++ b/README_js.md
@@ -498,7 +498,12 @@ Prior to `uuid@11`, it was possible for `options` state to interfere with the in
 
 ## Known issues
 
-### React Native / Expo
+<!-- This header is referenced as an anchor in src/rng-browser.ts -->
+### "getRandomValues() not supported"
+
+This error occurs in environments where the standard [`crypto.getRandomValues()`](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/getRandomValues) API is not supported. This issue can be resolved by adding an appropriate polyfill:
+
+#### React Native / Expo
 
 1. Install [`react-native-get-random-values`](https://github.com/LinusU/react-native-get-random-values#readme)
 1. Import it _before_ `uuid`. Since `uuid` might also appear as a transitive dependency of some other imports it's safest to just import `react-native-get-random-values` as the very first thing in your entry point:


### PR DESCRIPTION
When using on React Native, there is a link shown, https://github.com/uuidjs/uuid#getrandomvalues-not-supported, if the polyfill react-native-get-random-values is not installed. However, this link's anchor is not working because the title in the README has changed.

The React Native info was removed in b08c122248950db0df371c79638e0c5ffe3d6726 and re-added in ae8f38657bca0ee053bf29c88c006b1ea05af1b5, but the heading was changed so this link was broken.

This patch re-adds that anchor so the link points the user to proper spot in the README.

<!--
Thank you for your contribution!

If your pull request contains considerable changes please run the benchmark before and after your
changes and include the results in the pull request description. To run the benchmark execute:

    npm run test:benchmark

from the root of this repository.
-->
