### PR TITLE
fix: v4 UUID generation with insufficient random bytes should match e…

### DIFF
--- a/src/test/v4.test.ts
+++ b/src/test/v4.test.ts
@@ -2,6 +2,9 @@ import * as assert from 'assert';
 import test, { describe } from 'node:test';
 import native from '../native.js';
 import v4 from '../v4.js';
+import parse from '../parse.js';
+import version from '../version.js';
+import { unsafeStringify } from '../stringify.js';
 
 const randomBytesFixture = Uint8Array.of(
   0x10,
@@ -21,7 +24,7 @@ const randomBytesFixture = Uint8Array.of(
   0x58,
   0x36
 );
-
+const randomBytesFixtureLess = Uint8Array.of(16);
 const expectedBytes = Uint8Array.of(
   16,
   145,
@@ -113,5 +116,22 @@ describe('v4', () => {
     expectedBuf.set(expectedBytes, 16);
 
     assert.deepEqual(buffer, expectedBuf);
+  });
+  test('fills three UUID into a buffer as expected', () => {
+    const buffer = new Uint8Array(16);
+    const resultBuffer = v4({ random: randomBytesFixtureLess }, buffer);
+    const id = unsafeStringify(resultBuffer);
+    const v = version(id);
+    parse(id);
+    assert.deepEqual(buffer[0], expectedBytes[0]);
+    assert.strictEqual(buffer[0], resultBuffer[0]);
+    assert.strictEqual(v, 4);
+  });
+  test('v4 UUID generation with insufficient random bytes should match expected bytes', () => {
+    const id = v4({ random: randomBytesFixtureLess });
+    const v = version(id);
+    const buffer = parse(id);
+    assert.deepEqual(buffer[0], expectedBytes[0]);
+    assert.strictEqual(v, 4);
   });
 });

--- a/src/v4.ts
+++ b/src/v4.ts
@@ -12,7 +12,14 @@ function v4(options?: Version4Options, buf?: Uint8Array, offset?: number): UUIDT
 
   options = options || {};
 
-  const rnds = options.random || (options.rng || rng)();
+  let rnds = options.random || (options.rng || rng)();
+  if (rnds.length < 16) {
+    const newRnds = new Uint8Array(16);
+    for (let i = 0; i < 16; i++) {
+      newRnds[i] = rnds[i] ?? Math.floor(Math.random() * 256);
+    }
+    rnds = newRnds;
+  }
 
   // Per 4.4, set bits for version and `clock_seq_hi_and_reserved`
   rnds[6] = (rnds[6] & 0x0f) | 0x40;
@@ -20,6 +27,9 @@ function v4(options?: Version4Options, buf?: Uint8Array, offset?: number): UUIDT
 
   // Copy bytes to buffer, if provided
   if (buf) {
+    if (buf.length < 16) {
+      throw new Error('The buffer length must not be less than 16');
+    }
     offset = offset || 0;
 
     for (let i = 0; i < 16; ++i) {


### PR DESCRIPTION
```TS

import { v4 as uuidv4 } from 'uuid';

const v4options = {
  random: Uint8Array.of(
    0x10,
    0x91,
    0x56,
    0xbe,
    0xc4,
    0xfb,
    0xc1,
    0xea,
    0x71,
    0xb4,
    0xef,
    0xe1,
    0x67,
    0x1c // Missing 2 item
  ),
};
uuidv4(v4options); // ⇨ '109156be-c4fb-41ea-b1b4-efe1671cundefinedundefined'