### PR TITLE
chore: add shellcheck linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
       - run: npm ci
       - run: npm run lint
       - run: npm run docs:diff
+      - name: Run Shellcheck
+        run: find . -name '*.sh' -print0 | xargs -0 shellcheck -x
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - run: npm run lint
       - run: npm run docs:diff
       - name: Run Shellcheck
-        run: find . -name '*.sh' -print0 | xargs -0 shellcheck -x
+        run: find . -type f -name "*.sh" -exec shellcheck {} +
 
   test:
     runs-on: ubuntu-latest

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -26,24 +26,24 @@ for MODULE_TYPE in esm cjs; do
   DIST_DIR="$DIR/${MODULE_TYPE}"
   BROWSER_DIR="$DIR/${MODULE_TYPE}-browser"
 
-  tsc -p tsconfig.${MODULE_TYPE}.json
+  tsc -p "tsconfig.${MODULE_TYPE}.json"
 
   # Clone files for browser builds
-  cp -pr ${DIST_DIR} ${BROWSER_DIR}
+  cp -pr "${DIST_DIR}" "${BROWSER_DIR}"
 
   # Remove browser files from non-browser builds
-  for FILE in ${DIST_DIR}/*-browser*;do
-    rm -f $FILE
+  for FILE in "${DIST_DIR}"/*-browser*;do
+    rm -f "$FILE"
   done
 
   # Move browser files into place for browser builds
   (
     # Temporarily cd into BROWSER_DIR to avoid having to deal with "-browser"
     # appearing in both the dir name and file name of FILE's full path
-    cd ${BROWSER_DIR}
+    cd "${BROWSER_DIR}"
 
     for FILE in *-browser*;do
-      mv $FILE ${FILE/-browser/}
+      mv "$FILE" "${FILE/-browser/}"
     done
   )
 

--- a/scripts/testpack.sh
+++ b/scripts/testpack.sh
@@ -6,19 +6,19 @@ cd "$ROOT" || exit 1
 
 TEST_DIR=$(mktemp -d)
 
-mkdir -p ${TEST_DIR}
+mkdir -p "${TEST_DIR}"
 
-trap 'rm -rf $TEST_DIR' EXIT
+trap 'rm -rf "$TEST_DIR"' EXIT
 
 # Create package tarball
-npm pack --pack-destination=${TEST_DIR}
+npm pack "--pack-destination=${TEST_DIR}"
 
 # Set up a test project in the test directory
-pushd ${TEST_DIR}
+pushd "${TEST_DIR}"
 npm init -y
-cp ${ROOT}/examples/node-commonjs/example.js commonjs.js
-cp ${ROOT}/examples/node-esmodules/example.mjs esmodules.mjs
-cp ${ROOT}/examples/node-esmodules/package.mjs esmodules-package.mjs
+cp "${ROOT}/examples/node-commonjs/example.js" commonjs.js
+cp "${ROOT}/examples/node-esmodules/example.mjs" esmodules.mjs
+cp "${ROOT}/examples/node-esmodules/package.mjs" esmodules-package.mjs
 
 # Install the tarball
 npm install uuid*.tgz


### PR DESCRIPTION
PR adds the `shellcheck` linter to check the shell scripts, and fixes the found issues. Nothing major, although the existing scripts might not work if there are spaces or asterisks in the development repo path. If you would like changes, please let me know.