### PR TITLE
feat: preserve types of passthrough buffers in v1-v7

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export type UUIDTypes = string | Uint8Array;
+export type UUIDTypes<TBuf extends Uint8Array = Uint8Array> = string | TBuf;
 
 export type Version1Options = {
   node?: Uint8Array;

--- a/src/v1.ts
+++ b/src/v1.ts
@@ -25,8 +25,16 @@ type V1State = {
 const _state: V1State = {};
 
 function v1(options?: Version1Options, buf?: undefined, offset?: number): string;
-function v1(options: Version1Options | undefined, buf: Uint8Array, offset?: number): Uint8Array;
-function v1(options?: Version1Options, buf?: Uint8Array, offset?: number): UUIDTypes {
+function v1<Buf extends Uint8Array = Uint8Array>(
+  options: Version1Options | undefined,
+  buf: Buf,
+  offset?: number
+): Buf;
+function v1<TBuf extends Uint8Array = Uint8Array>(
+  options?: Version1Options,
+  buf?: TBuf,
+  offset?: number
+): UUIDTypes<TBuf> {
   let bytes: Uint8Array;
 
   // Extract _v6 flag from options, clearing options if appropriate
@@ -73,7 +81,7 @@ function v1(options?: Version1Options, buf?: Uint8Array, offset?: number): UUIDT
     );
   }
 
-  return buf ? bytes : unsafeStringify(bytes);
+  return buf ?? unsafeStringify(bytes);
 }
 
 // (Private!)  Do not use.  This method is only exported for testing purposes

--- a/src/v3.ts
+++ b/src/v3.ts
@@ -10,13 +10,18 @@ function v3(
   buf?: undefined,
   offset?: number
 ): string;
-function v3(
+function v3<TBuf extends Uint8Array = Uint8Array>(
   value: string | Uint8Array,
   namespace: UUIDTypes,
-  buf: Uint8Array,
+  buf: TBuf,
   offset?: number
-): Uint8Array;
-function v3(value: string | Uint8Array, namespace: UUIDTypes, buf?: Uint8Array, offset?: number) {
+): TBuf;
+function v3<TBuf extends Uint8Array = Uint8Array>(
+  value: string | Uint8Array,
+  namespace: UUIDTypes,
+  buf?: TBuf,
+  offset?: number
+): UUIDTypes<TBuf> {
   return v35(0x30, md5, value, namespace, buf, offset);
 }
 

--- a/src/v35.ts
+++ b/src/v35.ts
@@ -20,14 +20,14 @@ export const URL = '6ba7b811-9dad-11d1-80b4-00c04fd430c8';
 
 type HashFunction = (bytes: Uint8Array) => Uint8Array;
 
-export default function v35(
+export default function v35<TBuf extends Uint8Array = Uint8Array>(
   version: 0x30 | 0x50,
   hash: HashFunction,
   value: string | Uint8Array,
   namespace: UUIDTypes,
-  buf?: Uint8Array,
+  buf?: TBuf,
   offset?: number
-) {
+): UUIDTypes<TBuf> {
   const valueBytes: Uint8Array = typeof value === 'string' ? stringToBytes(value) : value;
   const namespaceBytes: Uint8Array = typeof namespace === 'string' ? parse(namespace) : namespace;
 

--- a/src/v4.ts
+++ b/src/v4.ts
@@ -4,8 +4,16 @@ import { unsafeStringify } from './stringify.js';
 import { UUIDTypes, Version4Options } from './types.js';
 
 function v4(options?: Version4Options, buf?: undefined, offset?: number): string;
-function v4(options: Version4Options | undefined, buf: Uint8Array, offset?: number): Uint8Array;
-function v4(options?: Version4Options, buf?: Uint8Array, offset?: number): UUIDTypes {
+function v4<TBuf extends Uint8Array = Uint8Array>(
+  options: Version4Options | undefined,
+  buf: TBuf,
+  offset?: number
+): TBuf;
+function v4<TBuf extends Uint8Array = Uint8Array>(
+  options?: Version4Options,
+  buf?: TBuf,
+  offset?: number
+): UUIDTypes<TBuf> {
   if (native.randomUUID && !buf && !options) {
     return native.randomUUID();
   }

--- a/src/v5.ts
+++ b/src/v5.ts
@@ -10,13 +10,18 @@ function v5(
   buf?: undefined,
   offset?: number
 ): string;
-function v5(
+function v5<TBuf extends Uint8Array = Uint8Array>(
   value: string | Uint8Array,
   namespace: UUIDTypes,
-  buf: Uint8Array,
+  buf: TBuf,
   offset?: number
-): Uint8Array;
-function v5(value: string | Uint8Array, namespace: UUIDTypes, buf?: Uint8Array, offset?: number) {
+): TBuf;
+function v5<TBuf extends Uint8Array = Uint8Array>(
+  value: string | Uint8Array,
+  namespace: UUIDTypes,
+  buf?: TBuf,
+  offset?: number
+): UUIDTypes<TBuf> {
   return v35(0x50, sha1, value, namespace, buf, offset);
 }
 

--- a/src/v6.ts
+++ b/src/v6.ts
@@ -4,8 +4,16 @@ import v1 from './v1.js';
 import v1ToV6 from './v1ToV6.js';
 
 function v6(options?: Version6Options, buf?: undefined, offset?: number): string;
-function v6(options: Version6Options | undefined, buf: Uint8Array, offset?: number): Uint8Array;
-function v6(options?: Version6Options, buf?: Uint8Array, offset?: number): UUIDTypes {
+function v6<TBuf extends Uint8Array = Uint8Array>(
+  options: Version6Options | undefined,
+  buf: TBuf,
+  offset?: number
+): TBuf;
+function v6<TBuf extends Uint8Array = Uint8Array>(
+  options?: Version6Options,
+  buf?: TBuf,
+  offset?: number
+): UUIDTypes<TBuf> {
   options ??= {};
   offset ??= 0;
 

--- a/src/v7.ts
+++ b/src/v7.ts
@@ -10,8 +10,16 @@ type V7State = {
 const _state: V7State = {};
 
 function v7(options?: Version7Options, buf?: undefined, offset?: number): string;
-function v7(options: Version7Options | undefined, buf: Uint8Array, offset?: number): Uint8Array;
-function v7(options?: Version7Options, buf?: Uint8Array, offset?: number): UUIDTypes {
+function v7<TBuf extends Uint8Array = Uint8Array>(
+  options: Version7Options | undefined,
+  buf: TBuf,
+  offset?: number
+): TBuf;
+function v7<TBuf extends Uint8Array = Uint8Array>(
+  options?: Version7Options,
+  buf?: TBuf,
+  offset?: number
+): UUIDTypes<TBuf> {
   let bytes: Uint8Array;
 
   if (options) {
@@ -33,7 +41,7 @@ function v7(options?: Version7Options, buf?: Uint8Array, offset?: number): UUIDT
     bytes = v7Bytes(rnds, _state.msecs, _state.seq, buf, offset);
   }
 
-  return buf ? bytes : unsafeStringify(bytes);
+  return buf ?? unsafeStringify(bytes);
 }
 
 // (Private!)  Do not use.  This method is only exported for testing purposes


### PR DESCRIPTION
The generator APIs accept a pre-allocated buffer and return said instance, but the function type signature didn't encode this information. Therefore we just need to sprinkle a few generics onto them to make it work.

This is mainly useful for nodejs users where `Buffer` accepting APIs are prevalent. Btw. the overload signatures ensure that the following does not compile:
```ts
v1<Buffer>(undefined, undefined)
```

It would be nice if `parse()` could optionally accept a buffer constructor, but that requires a bit more thought.