### PR TITLE
refactor: improve imports for the Node assert and test modules

### DIFF
--- a/src/test/parse.test.ts
+++ b/src/test/parse.test.ts
@@ -1,5 +1,5 @@
-import * as assert from 'assert';
-import test, { describe } from 'node:test';
+import * as assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import parse from '../parse.js';
 import stringify from '../stringify.js';
 import uuidv4 from '../v4.js';

--- a/src/test/rng.test.ts
+++ b/src/test/rng.test.ts
@@ -1,5 +1,5 @@
-import * as assert from 'assert';
-import test, { describe } from 'node:test';
+import * as assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import rng from '../rng.js';
 
 describe('rng', () => {

--- a/src/test/stringify.test.ts
+++ b/src/test/stringify.test.ts
@@ -1,5 +1,5 @@
-import * as assert from 'assert';
-import test, { describe } from 'node:test';
+import * as assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import stringify, { unsafeStringify } from '../stringify.js';
 
 const BYTES = Uint8Array.of(

--- a/src/test/v1.test.ts
+++ b/src/test/v1.test.ts
@@ -1,5 +1,5 @@
-import * as assert from 'assert';
-import test, { describe } from 'node:test';
+import * as assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import parse from '../parse.js';
 import v1, { updateV1State } from '../v1.js';
 

--- a/src/test/v35.test.ts
+++ b/src/test/v35.test.ts
@@ -1,5 +1,5 @@
-import * as assert from 'assert';
-import test, { describe } from 'node:test';
+import * as assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import md5 from '../md5.js';
 import sha1 from '../sha1.js';
 import v3 from '../v3.js';

--- a/src/test/v4.test.ts
+++ b/src/test/v4.test.ts
@@ -1,5 +1,5 @@
-import * as assert from 'assert';
-import test, { describe } from 'node:test';
+import * as assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import native from '../native.js';
 import v4 from '../v4.js';
 

--- a/src/test/v6.test.ts
+++ b/src/test/v6.test.ts
@@ -1,5 +1,5 @@
-import * as assert from 'assert';
-import test, { describe } from 'node:test';
+import * as assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import v1ToV6 from '../v1ToV6.js';
 import v6 from '../v6.js';
 import v6ToV1 from '../v6ToV1.js';

--- a/src/test/v7.test.ts
+++ b/src/test/v7.test.ts
@@ -1,5 +1,5 @@
-import * as assert from 'assert';
-import test, { describe } from 'node:test';
+import * as assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import parse from '../parse.js';
 import stringify from '../stringify.js';
 import { Version7Options } from '../types.js';

--- a/src/test/validate.test.ts
+++ b/src/test/validate.test.ts
@@ -1,5 +1,5 @@
-import * as assert from 'assert';
-import test, { describe } from 'node:test';
+import * as assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import validate from '../validate.js';
 import { TESTS } from './test_constants.js';
 

--- a/src/test/version.test.ts
+++ b/src/test/version.test.ts
@@ -1,5 +1,5 @@
-import * as assert from 'assert';
-import test, { describe } from 'node:test';
+import * as assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import version from '../version.js';
 import { TESTS } from './test_constants.js';
 

--- a/src/uuid-bin.ts
+++ b/src/uuid-bin.ts
@@ -1,4 +1,4 @@
-import * as assert from 'assert';
+import * as assert from 'node:assert/strict';
 
 import v1 from './v1.js';
 import v3 from './v3.js';


### PR DESCRIPTION
Just some test-related improvements I thought would be nice to contribute.

Node's assert module:
* Use protocol import (prefixed with `node:`).
* Use [strict assertion mode](https://nodejs.org/api/assert.html#strict-assertion-mode) (import from `node:assert/strict`).

Node's test runner:
* Import `test` as a named import, rather than a default import.