### PR TITLE
chore(ci): add workflow permissions

### DIFF
--- a/.github/workflows/browser.yml
+++ b/.github/workflows/browser.yml
@@ -6,6 +6,9 @@ on:
   pull_request_target:
     types: [labeled]
 
+permissions:
+  contents: read
+
 env:
   HUSKY: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 env:
   HUSKY: 0
 


### PR DESCRIPTION
Potential fix for [https://github.com/uuidjs/uuid/security/code-scanning/5](https://github.com/uuidjs/uuid/security/code-scanning/5)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will explicitly define the permissions for the `GITHUB_TOKEN`. Since the workflow primarily involves linting, testing, and documentation checks, it does not require write permissions. Therefore, we will set `contents: read` as the minimal required permission. This change will apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
