### PR TITLE
feat!: update to typescript@5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/esm/bin/uuid"
+        "uuid": "dist/bin/uuid"
       },
       "devDependencies": {
         "@babel/eslint-parser": "7.27.1",
@@ -35,7 +35,7 @@
         "release-please": "17.0.0",
         "runmd": "1.4.1",
         "standard-version": "9.5.0",
-        "typescript": "5.0.4",
+        "typescript": "5.2.2",
         "typescript-eslint": "8.32.0"
       }
     },
@@ -14235,9 +14235,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
-      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -14245,7 +14245,7 @@
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=12.20"
+        "node": ">=14.17"
       }
     },
     "node_modules/typescript-eslint": {
@@ -24373,9 +24373,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
-      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true
     },
     "typescript-eslint": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "release-please": "17.0.0",
     "runmd": "1.4.1",
     "standard-version": "9.5.0",
-    "typescript": "5.0.4",
+    "typescript": "5.2.2",
     "typescript-eslint": "8.32.0"
   },
   "optionalDevDependencies": {


### PR DESCRIPTION
Updating as part of the 12.x release.  Our policy for typescript is to support releases up to two years back. `5.2.2` was released 2023-08-24T16:38:15.233Z, so I'll hold off on publishing the 12.x release (that includes this) until 2025-08-24.

See also #856