### PR TITLE
feat!: use crypto.getRandomValues instead of randomFillSync

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ npm install uuid
 ```javascript
 import { v4 as uuidv4 } from 'uuid';
 
-uuidv4(); // ⇨ '9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d'
+uuidv4(); // ⇨ 'fd0fa6bf-9d33-4ce1-b78b-0f8104dc6d7c'
 ```
 
 For timestamp UUIDs, namespace UUIDs, and other options read on ...
@@ -187,7 +187,7 @@ Example:
 ```javascript
 import { v1 as uuidv1 } from 'uuid';
 
-uuidv1(); // ⇨ '2c5ea4c0-4067-11e9-9b5d-ab8dfbbd4bed'
+uuidv1(); // ⇨ 'dc812a70-7081-11f0-8234-1bfe823645a5'
 ```
 
 Example using `options`:
@@ -242,7 +242,7 @@ Example:
 ```javascript
 import { v4 as uuidv4 } from 'uuid';
 
-uuidv4(); // ⇨ '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed'
+uuidv4(); // ⇨ '873319c1-b93f-4613-946b-29ba7416436d'
 ```
 
 Example using predefined `random` values:
@@ -318,7 +318,7 @@ This method takes the same arguments as uuid.v1().
 ```javascript
 import { v6 as uuidv6 } from 'uuid';
 
-uuidv6(); // ⇨ '1e940672-c5ea-64c1-9bdd-2b0d7b3dcb6d'
+uuidv6(); // ⇨ '1f07081d-c819-6fa0-8528-b28245ce6dfb'
 ```
 
 Example using `options`:
@@ -365,7 +365,7 @@ Example:
 ```javascript
 import { v7 as uuidv7 } from 'uuid';
 
-uuidv7(); // ⇨ '01695553-c90c-745a-b76f-770d7b3dcb6d'
+uuidv7(); // ⇨ '019870a2-6e9b-77a0-8b90-66e6b5f0c427'
 ```
 
 ### ~~uuid.v8()~~

--- a/README_js.md
+++ b/README_js.md
@@ -5,18 +5,6 @@ runmd.onRequire = (path) => {
   if (path == 'rng') return fun;
   return path.replace(/^uuid/, './dist/');
 };
-
-// Shim Date and crypto so generated ids are consistent across doc revisions
-runmd.Date.now = () => 1551914748172;
-
-let seed = 0xdefaced;
-crypto.randomFillSync = function (a) {
-  for (let i = 0; i < a.length; i++) a[i] = (seed = (seed * 0x41a7) & 0x7fffffff) & 0xff;
-  return a;
-};
-
-// Prevent usage of native randomUUID implementation to ensure deterministic UUIDs
-crypto.randomUUID = undefined;
 ```
 
 # uuid [![CI](https://github.com/uuidjs/uuid/workflows/CI/badge.svg)](https://github.com/uuidjs/uuid/actions?query=workflow%3ACI) [![Browser](https://github.com/uuidjs/uuid/workflows/Browser/badge.svg)](https://github.com/uuidjs/uuid/actions/workflows/browser.yml)

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "build": "./scripts/build.sh",
     "build:watch": "tsc --watch -p tsconfig.json",
     "bundlewatch": "npm run pretest:browser && bundlewatch --config bundlewatch.config.json",
-    "docs:diff": "git diff --quiet -I \"[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}\" README.md",
+    "docs:diff": "npm run docs && git diff --quiet -I \"[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}\" README.md",
     "docs": "npm run build && npx runmd --output=README.md README_js.md",
     "eslint:check": "eslint src/ test/ examples/ *.[jt]s",
     "eslint:fix": "eslint --fix src/ test/ examples/ *.[jt]s",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "build": "./scripts/build.sh",
     "build:watch": "tsc --watch -p tsconfig.json",
     "bundlewatch": "npm run pretest:browser && bundlewatch --config bundlewatch.config.json",
-    "docs:diff": "npm run docs && git diff --quiet README.md",
+    "docs:diff": "git diff --quiet -I \"[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}\" README.md",
     "docs": "npm run build && npx runmd --output=README.md README_js.md",
     "eslint:check": "eslint src/ test/ examples/ *.[jt]s",
     "eslint:fix": "eslint --fix src/ test/ examples/ *.[jt]s",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,11 +1,8 @@
 #!/bin/bash -eu
 
-# This script generates 4 builds, as follows:
+# This script generates the following builds:
 # - dist: ESM build for Node.js
 # - dist-browser: ESM build for the Browser
-#
-# Note: that the "preferred" build for testing (local and CI) is the ESM build,
-# except where we specifically test the other builds
 
 set -e # exit on error
 

--- a/src/rng-browser.ts
+++ b/src/rng-browser.ts
@@ -1,13 +1,9 @@
-// Unique ID creation requires a high quality random # generator. In the browser we therefore
-// require the crypto API and do not support built-in fallback to lower quality random number
-// generators (like Math.random()).
-
 let getRandomValues: typeof crypto.getRandomValues | undefined;
 
 const rnds8 = new Uint8Array(16);
 
 export default function rng() {
-  // lazy load so that environments that need to polyfill have a chance to do so
+  // lazy-reference getRandomValues in case it's been polyfilled
   if (!getRandomValues) {
     if (typeof crypto === 'undefined' || !crypto.getRandomValues) {
       throw new Error(

--- a/src/rng.ts
+++ b/src/rng.ts
@@ -2,11 +2,16 @@
 // can switch to `globalThis.crypto` and combine `rng.ts` and `rng-browser.ts`.
 import { webcrypto } from 'node:crypto';
 
-const getRandomValues = webcrypto.getRandomValues.bind(webcrypto);
+let getRandomValues: typeof webcrypto.getRandomValues | undefined;
 const rnds8Pool = new Uint8Array(256); // # of random values to pre-allocate
 let poolPtr = rnds8Pool.length;
 
 export default function rng() {
+  // lazy-reference getRandomValues in case it's been polyfilled
+  if (!getRandomValues) {
+    getRandomValues = webcrypto.getRandomValues.bind(webcrypto);
+  }
+
   if (poolPtr > rnds8Pool.length - 16) {
     getRandomValues(rnds8Pool);
     poolPtr = 0;

--- a/src/rng.ts
+++ b/src/rng.ts
@@ -1,11 +1,13 @@
-import { randomFillSync } from 'node:crypto';
+// Required for Node.js 18. Can be removed when support for Node.js 18 is dropped.
+import { webcrypto } from 'node:crypto';
 
+const getRandomValues = webcrypto.getRandomValues.bind(webcrypto);
 const rnds8Pool = new Uint8Array(256); // # of random values to pre-allocate
 let poolPtr = rnds8Pool.length;
 
 export default function rng() {
   if (poolPtr > rnds8Pool.length - 16) {
-    randomFillSync(rnds8Pool);
+    getRandomValues(rnds8Pool);
     poolPtr = 0;
   }
   return rnds8Pool.slice(poolPtr, (poolPtr += 16));

--- a/src/rng.ts
+++ b/src/rng.ts
@@ -1,4 +1,5 @@
-// Required for Node.js 18. Can be removed when support for Node.js 18 is dropped.
+// `crypto` import here is required for node@18. Once v18 support is dropped we
+// can switch to `globalThis.crypto` and combine `rng.ts` and `rng-browser.ts`.
 import { webcrypto } from 'node:crypto';
 
 const getRandomValues = webcrypto.getRandomValues.bind(webcrypto);


### PR DESCRIPTION
This improves compatibility with other server runtimes such as Cloudflare Workers that don't support Node's crypto module out of the box.

I tried to dig into the history of the use of `randomFillSync`. The change was done in #435 but a justification was not mentioned in the commit or the PR.

If this is approved it would also open up the possibility of merging the two RNG implementations for node and browsers into a common one.

Benchmark before:

```
uuid.stringify() x 5,294,261 ops/sec ±2.28% (90 runs sampled)
uuid.parse() x 4,008,788 ops/sec ±0.90% (96 runs sampled)
---

uuid.v1() x 4,394,917 ops/sec ±0.75% (96 runs sampled)
uuid.v1() fill existing array x 7,200,421 ops/sec ±0.69% (93 runs sampled)
uuid.v4() x 10,264,478 ops/sec ±0.60% (97 runs sampled)
uuid.v4() fill existing array x 9,653,512 ops/sec ±0.70% (95 runs sampled)
uuid.v4() without native generation x 4,402,382 ops/sec ±0.34% (97 runs sampled)
uuid.v3() x 748,220 ops/sec ±0.29% (98 runs sampled)
uuid.v5() x 791,018 ops/sec ±0.26% (97 runs sampled)
uuid.v6() x 2,472,765 ops/sec ±0.25% (91 runs sampled)
uuid.v7() x 4,784,766 ops/sec ±0.47% (98 runs sampled)
uuid.v7() fill existing array x 8,528,953 ops/sec ±0.34% (98 runs sampled)
uuid.v7() with defined time x 5,180,108 ops/sec ±0.26% (100 runs sampled)
Fastest is uuid.v4()
---

uuid.v1ToV6() x 2,500,811 ops/sec ±0.42% (97 runs sampled)
uuid.v6ToV1() x 2,448,658 ops/sec ±0.72% (94 runs sampled)
```

Benchmark after:

```
uuid.stringify() x 5,287,311 ops/sec ±0.48% (94 runs sampled)
uuid.parse() x 4,070,022 ops/sec ±0.29% (96 runs sampled)
---

uuid.v1() x 3,562,691 ops/sec ±0.17% (98 runs sampled)
uuid.v1() fill existing array x 7,241,696 ops/sec ±0.20% (99 runs sampled)
uuid.v4() x 10,376,376 ops/sec ±0.31% (96 runs sampled)
uuid.v4() fill existing array x 10,066,924 ops/sec ±0.30% (99 runs sampled)
uuid.v4() without native generation x 4,442,705 ops/sec ±0.46% (98 runs sampled)
uuid.v3() x 687,526 ops/sec ±3.20% (92 runs sampled)
uuid.v5() x 757,411 ops/sec ±0.99% (92 runs sampled)
uuid.v6() x 2,428,337 ops/sec ±0.30% (95 runs sampled)
uuid.v7() x 4,740,402 ops/sec ±0.73% (95 runs sampled)
uuid.v7() fill existing array x 8,496,746 ops/sec ±0.54% (96 runs sampled)
uuid.v7() with defined time x 5,193,370 ops/sec ±0.23% (99 runs sampled)
Fastest is uuid.v4()
---

uuid.v1ToV6() x 2,503,294 ops/sec ±0.17% (97 runs sampled)
uuid.v6ToV1() x 2,500,651 ops/sec ±0.21% (98 runs sampled)
```